### PR TITLE
docs: add a live MCP status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/ondata/ckan-mcp-server)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Newsletter](https://img.shields.io/badge/newsletter-ondata-FF6719?logo=substack)](https://ondata.substack.com/)
+[![MCP status](https://mcpvitals.com/badge/1b08365a88.svg)](https://mcpvitals.com/status/1b08365a88)
 
 # CKAN MCP Server
 


### PR DESCRIPTION
Hi — this adds a small status badge for the hosted Worker endpoint, so anyone landing on the README can see whether it's currently answering before they wire it into a client.

It runs the actual MCP handshake (`initialize` → `tools/list`), not an HTTP ping, and links to a public status page with uptime history. Healthy with 20 tools right now. I've added it to the end of the existing badge row and changed nothing else.

One line, no tracking. Close if not wanted.

---
*Disclosure: I build MCP Vitals, the service behind this badge — so I have an interest here. I also used an AI assistant to help prepare this PR. The check is real and reproducible without me: `npx @mcpvitals/cli check <your-endpoint>`. Close it freely if it isn't a fit.*