### PR TITLE
fix(ssrf): refuse env proxies, block multicast/reserved/site-local ranges

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,14 @@
 # LOG
 
+## 2026-09-04
+
+### SSRF guard aligned with datagouv-mcp v1.0.0
+
+Compared our `isBlockedIp` and request chain against the SSRF hardening shipped in [datagouv-mcp v1.0.0](https://github.com/datagouv/datagouv-mcp/releases/tag/v1.0.0) (PR #126, external report). Connect-time pinning, redirect re-checks and IPv4-mapped/6to4/NAT64 unwrapping were already in place; their specific vector (fetching producer-supplied URLs from catalog metadata) does not apply here. Two gaps closed:
+
+- `proxy: false` on the axios path: with `HTTP_PROXY`/`HTTPS_PROXY` set, axios connected to the proxy and the SSRF-safe lookup validated only the proxy's IP, not the target's.
+- `isBlockedIp` now also rejects 224.0.0.0/4 (multicast), 240.0.0.0/4 (reserved), ff00::/8 (IPv6 multicast) and fec0::/10 (site-local). Running their 37 test cases against our function surfaced exactly these.
+
 ## 2026-08-31
 
 ### Support #4682889 answered: the Advisory Database queue reaches back to June 2026

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -330,7 +330,9 @@ export function isBlockedIp(ip: string): boolean {
       w[0] === 0x2002 ||                           // 2002::/16 6to4
       (w[0] === 0x2001 && w[1] === 0x0000) ||      // 2001::/32 Teredo
       (w[0] & 0xfe00) === 0xfc00 ||                // fc00::/7 unique local
-      (w[0] & 0xffc0) === 0xfe80                   // fe80::/10 link-local
+      (w[0] & 0xffc0) === 0xfe80 ||                // fe80::/10 link-local
+      (w[0] & 0xffc0) === 0xfec0 ||                // fec0::/10 site-local (deprecated)
+      (w[0] & 0xff00) === 0xff00                   // ff00::/8 multicast
     );
   }
 
@@ -348,7 +350,7 @@ export function isBlockedIp(ip: string): boolean {
     (o1 === 172 && o2 >= 16 && o2 <= 31) ||  // 172.16.0.0/12 private
     (o1 === 192 && o2 === 168) ||            // 192.168.0.0/16 private
     (o1 === 198 && (o2 === 18 || o2 === 19)) || // 198.18.0.0/15 benchmarking
-    o1 === 255                               // broadcast
+    o1 >= 224                                // 224.0.0.0/4 multicast, 240.0.0.0/4 reserved, broadcast
   );
 }
 
@@ -713,6 +715,9 @@ export async function makeCkanRequest<T>(
         timeout: 30000,
         responseType: "arraybuffer",
         maxRedirects: 5,
+        // Never route through HTTP_PROXY/HTTPS_PROXY: a proxy would connect to the
+        // target itself, bypassing the SSRF-safe lookup pinned in the agents below.
+        proxy: false,
         maxContentLength: MAX_RESPONSE_BYTES,
         maxBodyLength: MAX_RESPONSE_BYTES,
         ...(safeAgents

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -154,6 +154,13 @@ describe('isBlockedIp', () => {
     expect(isBlockedIp('198.17.0.1')).toBe(false);
     expect(isBlockedIp('198.20.0.1')).toBe(false);
   });
+
+  it('blocks multicast, reserved and site-local ranges', () => {
+    for (const ip of ['224.0.0.1', '239.255.255.255', '240.0.0.1', '255.255.255.255', 'ff00::1', 'ff02::1', 'fec0::1', 'feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff']) {
+      expect(isBlockedIp(ip), ip).toBe(true);
+    }
+    expect(isBlockedIp('223.255.255.254')).toBe(false);
+  });
 });
 
 describe('GHSA-x32r-mh7g-q2rf bypass chain', () => {

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -442,7 +442,7 @@ describe('makeCkanRequest', () => {
   it("disables environment proxies so the SSRF-safe lookup pins the real target", async () => {
     vi.mocked(axios.get).mockResolvedValue({ data: successResponse });
 
-    await makeCkanRequest("http://demo.ckan.org", "ckan_status_show");
+    await makeCkanRequest("https://www.dati.gov.it/opendata", "ckan_status_show");
 
     const axiosCall = vi.mocked(axios.get).mock.calls[0];
     expect(axiosCall[1].proxy).toBe(false);

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -155,11 +155,11 @@ describe('isBlockedIp', () => {
     expect(isBlockedIp('198.20.0.1')).toBe(false);
   });
 
-  it('blocks multicast, reserved and site-local ranges', () => {
-    for (const ip of ['224.0.0.1', '239.255.255.255', '240.0.0.1', '255.255.255.255', 'ff00::1', 'ff02::1', 'fec0::1', 'feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff']) {
+  it("blocks multicast, reserved and site-local ranges", () => {
+    for (const ip of ["224.0.0.1", "239.255.255.255", "240.0.0.1", "255.255.255.255", "ff00::1", "ff02::1", "fec0::1", "feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"]) {
       expect(isBlockedIp(ip), ip).toBe(true);
     }
-    expect(isBlockedIp('223.255.255.254')).toBe(false);
+    expect(isBlockedIp("223.255.255.254")).toBe(false);
   });
 });
 
@@ -437,6 +437,15 @@ describe('makeCkanRequest', () => {
     expect(axiosCall[1].headers['User-Agent']).toBe(
       'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
     );
+  });
+
+  it("disables environment proxies so the SSRF-safe lookup pins the real target", async () => {
+    vi.mocked(axios.get).mockResolvedValue({ data: successResponse });
+
+    await makeCkanRequest("http://demo.ckan.org", "ckan_status_show");
+
+    const axiosCall = vi.mocked(axios.get).mock.calls[0];
+    expect(axiosCall[1].proxy).toBe(false);
   });
 
   it('throws error when success=false in response', async () => {


### PR DESCRIPTION
Aligned our SSRF guard with the hardening shipped in [datagouv-mcp v1.0.0](https://github.com/datagouv/datagouv-mcp/releases/tag/v1.0.0) (PR datagouv/datagouv-mcp#126, external report). Connect-time pinning, redirect re-checks and IPv4-mapped/6to4/NAT64 unwrapping were already in place; their specific vector (fetching producer-supplied URLs from catalog metadata) does not apply here. Two gaps closed:

- `proxy: false` on the axios path: with `HTTP_PROXY`/`HTTPS_PROXY` set, axios connected to the proxy and the SSRF-safe lookup validated only the proxy's IP, not the target's.
- `isBlockedIp` now also rejects 224.0.0.0/4 (multicast), 240.0.0.0/4 (reserved), ff00::/8 (IPv6 multicast) and fec0::/10 (site-local). Running datagouv's 37 test cases against our function surfaced exactly these.

## Test plan
- [x] `npm run build`
- [x] `npm test` (496 passed, 8 new cases in `tests/unit/http.test.ts`)
- [x] Real HTTP e2e: `ckan_package_search` against dati.gov.it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtqW9nD9oBQT39xB4mj2bg
