### PR TITLE
fix(errors): 404 on datastore_search_sql means the portal has no SQL endpoint

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -2,6 +2,22 @@
 
 ## 2026-09-05
 
+### 404 on datastore_search_sql: hint sent callers round a loop
+
+A 404 on `datastore_search_sql` fell into the generic `datastore_search` branch of
+`formatCkanError`, which answers "get a valid resource_id first: call `ckan_package_show`".
+On a portal that does not expose SQL the resource_id is fine and `ckan_package_show`
+hands back the same one, so a client following the hint retries into the same 404.
+
+SQL access is optional in CKAN and widely disabled: `datastore_search_sql?sql=SELECT 1`
+returns 404 on Toronto's portal and 200 on dati.comune.messina.it, while
+`datastore_search` answers 200 on both. A bad table name comes back as a 400, not a 404,
+so a 404 on that action means the endpoint itself is missing. The hint now says so and
+points at `ckan_datastore_search`.
+
+Verified e2e: Toronto returns the new hint; Messina counts 202.906 rows in a single SQL
+call. 498 tests pass, one added.
+
 ### Telemetry pipeline: cross-worker contamination, missing outcome, unattributable errors
 
 A usage review of `worker_events_flat.jsonl` surfaced three defects in the measurement itself, all confirmed against the live Observability API:

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -38,7 +38,13 @@ export function formatCkanError(error: unknown, _toolName: string): string {
   const { status, action, message } = error;
   let hint = '';
   if (status === 404) {
-    if (action.startsWith('datastore_search')) {
+    if (action === 'datastore_search_sql') {
+      // SQL access is optional in CKAN and many portals disable it, answering 404 on
+      // the endpoint itself. The resource_id is usually fine — a bad table name comes
+      // back as a 400 instead — so pointing at `ckan_package_show` sends the caller
+      // round a loop that ends on the same 404.
+      hint = '→ This portal does not expose the SQL endpoint (optional in CKAN, often disabled). Use `ckan_datastore_search` with `filters`/`sort` instead; the resource_id is probably fine.';
+    } else if (action.startsWith('datastore_search')) {
       hint = '→ Get a valid resource_id first: call `ckan_package_show` on a dataset, then pick a resource where `datastore_active` is true.';
     } else if (action === 'package_show') {
       hint = '→ Use `ckan_package_search` to find a valid dataset name or ID.';

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -774,6 +774,16 @@ describe('formatCkanError', () => {
     expect(result).toContain('datastore_active');
   });
 
+  it('404 on datastore_search_sql says the portal lacks the SQL endpoint, not that the resource_id is wrong', () => {
+    const err = new CkanApiError('CKAN API error (404): Not Found', 404, 'datastore_search_sql');
+    const result = formatCkanError(err, 'ckan_datastore_search_sql');
+    expect(result).toContain('does not expose the SQL endpoint');
+    expect(result).toContain('ckan_datastore_search');
+    // the old hint sent the caller to package_show, which returns the same
+    // resource_id and loops straight back into this 404
+    expect(result).not.toContain('ckan_package_show');
+  });
+
   it('404 on package_show mentions ckan_package_search', () => {
     const err = new CkanApiError('CKAN API error (404): Not Found', 404, 'package_show');
     const result = formatCkanError(err, 'ckan_package_show');


### PR DESCRIPTION
## Problem

A 404 on `datastore_search_sql` fell into the generic `datastore_search` branch of `formatCkanError`, which answers:

```
→ Get a valid resource_id first: call `ckan_package_show` on a dataset,
  then pick a resource where `datastore_active` is true.
```

On a portal that does not expose SQL the resource_id is fine. `ckan_package_show` hands back the same one, the client retries, and lands on the same 404 — the hint describes a loop rather than a way out.

## Why a 404 there means something else

SQL access is optional in CKAN and widely disabled. Measured on two live portals:

| portal | `datastore_search_sql?sql=SELECT 1` | `datastore_search` |
|---|---|---|
| `ckan0.cf.opendata.inter.prod-toronto.ca` | 404 | 200 |
| `dati.comune.messina.it` | 200 | 200 |

A bad table name in the SQL comes back as a 400, not a 404, so a 404 on that action means the endpoint itself is missing. The hint now says so and points at `ckan_datastore_search`, which works on both portals.

## Changes

- `src/utils/http.ts`: dedicated 404 branch for `datastore_search_sql`, ahead of the generic `datastore_search` one, with a comment explaining why the two differ
- `tests/unit/http.test.ts`: one test, which also asserts the message no longer mentions `ckan_package_show`
- `LOG.md` entry

## Verification

- `npm run build`, then `npm test`: 498 passed, 6 skipped
- e2e against a local HTTP server on the two real portals:
  - Toronto returns the new hint
  - Messina executes the SQL and counts 202.906 rows in a single call

## Note on the history

This change was first pushed straight to `main` as 11cb7b7 by mistake, then reverted in 8fcdaa0. `main` carries a `non_fast_forward` rule, so the history was not rewritten. This PR reintroduces the same diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEpSWpAwuMaGkfnMpQdqK2
