### PR TITLE
fix(search): wrap only boolean queries, probe every portal for the verdict

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -2,6 +2,52 @@
 
 ## 2026-09-05
 
+### Solr: wrap only boolean queries, and measure every portal instead of storing a verdict
+
+The usage review surfaced an LLM client reformulating the same request against
+`www.dati.gov.it/opendata` for three hours on 29 July. The data was there from the first
+attempt: `bonifica siti contaminati Piemonte` returns 22 datasets on that portal, the
+Piedmont contaminated-sites registry first. Our `text:(...)` rewrite was returning 5.
+
+`package_search` hands a colon-free query to Solr's dismax parser with `q.op=AND`,
+`mm='2<-1 5<80%'` and `qf='name^4 title^4 tags^2 groups^2 text'` (`ckan/lib/search/query.py`).
+dismax has no boolean syntax, so `A OR B` collapses into `A AND B`: on dati.gov.it
+`aria OR Milano` returns 59, exactly what `aria AND Milano` returns. A colon takes the query
+off dismax, which is what the wrapper exploits — the wrapped form returns 3421. The same
+switch is why it hurts everything else: it drops the `qf` boosts that rank titles and tags
+first, searches the catch-all `text` field alone, and ANDs every term instead of applying
+`mm`. This is CKAN's own default, not a per-portal defect, which is why the same pattern
+showed up on Milano, Toscana, Sicilia, Ucraina and open.canada.ca.
+
+Measured on dati.gov.it: `defibrillatori Comune di Lecce` 678 -> 1, `qualità aria Milano`
+650 -> 51, `musei roma arte opere catalogo` 9 -> 0 — the second most repeated query of the
+semester, answered with an empty page while nine datasets existed. On 40 real queries from
+telemetry the separation is clean: with a boolean operator the wrapper helped 8 times and
+hurt none; without one it helped none and hurt 10, six of them down to zero.
+
+So the wrapper now applies only to queries carrying a boolean operator. The shape that an
+LLM client generates from a user's request — a run of keywords, no operators — is left to
+the portal's own parser, boosts and `mm` included.
+
+`probePortalParser` was rewritten and now runs for every portal, configured ones included;
+`force_text_field` is gone from `portals.json` (8 entries) so there is one source of truth.
+The old probe asked `data OR dati`, two words common enough to saturate: on Milano `data`
+alone and `data OR dati` both return 2564, so it read the portal as healthy while
+`aria OR acqua` returned 0 against 54 and 33 for the single terms. It now picks two terms
+from the catalog itself — single-word tag facets between 0.5% and 30%, falling back to
+frequent title words — and compares `A`, `B`, `A OR B`, `text:(A OR B)`. An OR returning
+fewer hits than either operand is not being honoured, and the wrapper is the answer only if
+the wrapped form returns more. `data.stadt-zuerich.ch`, where the `text` field returns 0 for
+every query, is correctly left alone.
+
+Cost: a plain query pays nothing, since nothing but a boolean query can be wrapped. The
+probe costs 5 extra `rows=0` calls the first time a boolean query reaches a portal in a
+session, then nothing.
+
+Verified e2e against live portals: dati.gov.it 5 -> 22 and 0 -> 9 on the two queries from
+the telemetry, Milano `aria OR acqua` 0 -> 87, Zurich unchanged at 10 and 172. 516 tests
+pass, 18 added.
+
 ### v0.4.121 - clearer 404 on datastore_search_sql
 
 Patch release for the fix in #532: a 404 on `datastore_search_sql` now says the portal does not expose the SQL endpoint, instead of sending the caller to `ckan_package_show` for a resource_id that was already valid. Also ships the telemetry pipeline fixes and the DEPLOYMENT.md/CLAUDE.md realignment from earlier today.

--- a/src/README.md
+++ b/src/README.md
@@ -53,10 +53,10 @@ Each entry in `portals` array supports:
   - Example: data.europa.eu requires this due to its DCAT-AP based field structure
 
 - **`search`** (object): Search behavior configuration
-  - **`force_text_field`** (boolean): Force wrapping non-fielded queries in `text:(...)`
-    - Default: `false`
-    - Set to `true` for portals with restrictive query parsers that break on long OR queries
-    - Example: dati.gov.it requires this to handle queries like `"hotel OR alberghi"`
+  - **`force_text_field`** (boolean): forces `text:(...)` wrapping on non-fielded queries.
+    Still honoured if present, but **no portal sets it any more** and new ones should not:
+    the decision is measured at runtime by `probePortalParser()` in `src/tools/package.ts`.
+    The stored values went stale and were removed on 2026-09-05.
 
 ### Defaults
 
@@ -72,6 +72,38 @@ The `defaults` object provides fallback values when a portal is not found in the
 }
 ```
 
+### Query parser: when `text:(...)` wrapping is applied
+
+`package_search` sends a colon-free query to Solr's **dismax** parser with `q.op=AND`,
+`mm='2<-1 5<80%'` and `qf='name^4 title^4 tags^2 groups^2 text'` (`ckan/lib/search/query.py`).
+dismax has no boolean syntax, so `A OR B` collapses into `A AND B`. A colon in the query
+takes it off dismax, which is what wrapping it as `text:(A OR B)` exploits.
+
+The same switch is why wrapping hurts everything else: it drops the `qf` boosts that rank
+titles and tags first, searches the catch-all `text` field alone, and ANDs every term
+instead of applying `mm`. Measured on dati.gov.it, 2026-09-05:
+
+| query | plain | `text:(...)` |
+|---|---|---|
+| `ambiente` | 8047 | 8047 |
+| `qualità aria Milano` | 650 | 51 |
+| `defibrillatori Comune di Lecce` | 678 | 1 |
+| `musei roma arte opere catalogo` | 9 | 0 |
+| `aria OR Milano` | 59 | 3421 |
+
+So the wrapper is applied **only to queries carrying a boolean operator**
+(`mayNeedTextWrapping` in `src/utils/search.ts`), and only when the portal needs it.
+
+`probePortalParser()` decides that per portal: it picks two terms that occur in the
+catalog — single-word tag facets between 0.5% and 30% of the catalog, falling back to
+frequent title words — and compares `A`, `B`, `A OR B` and `text:(A OR B)`. An `A OR B`
+returning fewer hits than `A` or `B` alone is not being honoured; the wrapper is the answer
+only if the wrapped form returns more. On `data.stadt-zuerich.ch` the `text` field returns 0
+for every query, so the probe correctly declines to wrap there.
+
+Cost: nothing for a plain query, 5 extra `rows=0` calls the first time a boolean query hits
+a portal in a session, nothing afterwards (cached, negative verdicts included).
+
 ### Adding a New Portal
 
 1. Add entry to `portals` array
@@ -79,7 +111,7 @@ The `defaults` object provides fallback values when a portal is not found in the
 3. Add `api_url_aliases` if the portal has multiple URL variants
 4. Set `api_path` if the portal uses non-standard API path (e.g., `/api/action/` instead of `/api/3/action/`)
 5. Customize `dataset_view_url` and/or `organization_view_url` only if non-standard
-6. Set `search.force_text_field: true` if the portal has query parser issues
+6. Leave `search.force_text_field` unset: the runtime probe decides
 7. Set `normalize: "multilingual"` if the portal uses multilingual/DCAT-AP field structures
 
 **Note**: To determine the correct `api_path`, test the portal's API endpoints:
@@ -158,7 +190,7 @@ The following portals have been tested and verified (as of v0.4.37):
 
 | Portal | Country | CKAN Version | Notes |
 |--------|---------|--------------|-------|
-| dati.gov.it/opendata | 🇮🇹 Italy | 2.10.3 | `force_text_field: true`; custom `dataset_view_url` and `organization_view_url` |
+| dati.gov.it/opendata | 🇮🇹 Italy | 2.10.3 | Custom `dataset_view_url` and `organization_view_url` |
 | dati.anticorruzione.it/opendata | 🇮🇹 Italy | — | Standard configuration |
 | catalog.data.gov | 🇺🇸 USA | 2.11.4 | Standard configuration |
 | open.canada.ca/data | 🇨🇦 Canada | 2.10.8 | Standard configuration |

--- a/src/portals.json
+++ b/src/portals.json
@@ -11,9 +11,6 @@
         "https://dati.gov.it",
         "https://www.dati.gov.it"
       ],
-      "search": {
-        "force_text_field": true
-      },
       "hvd": {
         "category_field": "hvd_category"
       },
@@ -30,10 +27,7 @@
       "api_url": "https://dati.arpae.it",
       "api_url_aliases": [
         "http://dati.arpae.it"
-      ],
-      "search": {
-        "force_text_field": true
-      }
+      ]
     },
     {
       "id": "anac-opendata",
@@ -55,9 +49,6 @@
         "http://www.data.gov.uk"
       ],
       "api_path": "/api/action",
-      "search": {
-        "force_text_field": true
-      },
       "dataset_view_url": "https://www.data.gov.uk/dataset/{id}/{name}",
       "organization_view_url": "https://www.data.gov.uk/organization/{name}"
     },
@@ -67,10 +58,7 @@
       "api_url": "https://catalog.data.gov",
       "api_url_aliases": [
         "http://catalog.data.gov"
-      ],
-      "search": {
-        "force_text_field": true
-      }
+      ]
     },
     {
       "id": "open-canada",
@@ -80,10 +68,7 @@
         "http://open.canada.ca/data",
         "https://open.canada.ca",
         "http://open.canada.ca"
-      ],
-      "search": {
-        "force_text_field": true
-      }
+      ]
     },
     {
       "id": "data-gov-au",
@@ -126,10 +111,7 @@
       "api_url": "https://data.gov.ua",
       "api_url_aliases": [
         "http://data.gov.ua"
-      ],
-      "search": {
-        "force_text_field": false
-      }
+      ]
     },
     {
       "id": "dati-regione-sicilia",
@@ -137,10 +119,7 @@
       "api_url": "https://dati.regione.sicilia.it",
       "api_url_aliases": [
         "http://dati.regione.sicilia.it"
-      ],
-      "search": {
-        "force_text_field": false
-      }
+      ]
     },
     {
       "id": "bdap-rgs-mef",
@@ -169,9 +148,6 @@
   ],
   "defaults": {
     "dataset_view_url": "{server_url}/dataset/{name}",
-    "organization_view_url": "{server_url}/organization/{name}",
-    "search": {
-      "force_text_field": false
-    }
+    "organization_view_url": "{server_url}/organization/{name}"
   }
 }

--- a/src/tools/package.ts
+++ b/src/tools/package.ts
@@ -18,6 +18,9 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
  */
 const _portalParserCache = new Map<string, boolean>();
 
+/** Terms safe to drop into a probe query verbatim: no Solr syntax. */
+const LITERAL_TERM = /^[\p{L}\p{N}_]+$/u;
+
 /**
  * Pick two terms that actually occur in this catalog, for the parser probe below.
  *
@@ -45,7 +48,10 @@ async function pickProbeTerms(serverUrl: string): Promise<[string, string] | nul
   const items: Array<{ name?: string; count?: number }> =
     facetRes?.search_facets?.tags?.items ?? [];
   const usable = items
-    .filter(i => typeof i.name === 'string' && !/\s/.test(i.name))
+    // Letters, digits and underscore only: a tag like `open-data` or one carrying a
+    // colon would be read as Solr syntax and skew the very query that measures the
+    // parser. Unescaped is the point — the probe must look like an ordinary search.
+    .filter(i => typeof i.name === 'string' && LITERAL_TERM.test(i.name))
     .filter(i => (i.count ?? 0) >= total * 0.005 && (i.count ?? 0) <= total * 0.3)
     .sort((a, b) => (b.count ?? 0) - (a.count ?? 0));
   if (usable.length >= 2) return [usable[0].name!, usable[1].name!];
@@ -55,12 +61,25 @@ async function pickProbeTerms(serverUrl: string): Promise<[string, string] | nul
     rows: 25
   }).catch(() => null);
   const titles: string[] = (sampleRes?.results ?? []).map((r: any) => r?.title ?? '');
+  const words = titles.map(t => new Set(t.toLowerCase().split(/[^\p{L}\p{N}_]+/u).filter(w => w.length > 4)));
   const freq = new Map<string, number>();
-  for (const word of titles.join(' ').toLowerCase().split(/[^\p{L}]+/u)) {
-    if (word.length > 4) freq.set(word, (freq.get(word) ?? 0) + 1);
-  }
-  const top = [...freq.entries()].sort((a, b) => b[1] - a[1]).slice(0, 2);
-  return top.length === 2 ? [top[0][0], top[1][0]] : null;
+  for (const set of words) for (const w of set) freq.set(w, (freq.get(w) ?? 0) + 1);
+
+  const ranked = [...freq.entries()]
+    .filter(([w]) => LITERAL_TERM.test(w))
+    .sort((a, b) => b[1] - a[1]);
+  const first = ranked[0]?.[0];
+  if (!first) return null;
+
+  // The second term must not be a synonym of the first: if the two always occur in
+  // the same titles, `A OR B` equals `A` even when the portal honours OR, and the
+  // probe would cache a false negative. Prefer the most frequent word that appears
+  // somewhere the first one does not.
+  const independent = ranked
+    .slice(1)
+    .find(([w]) => words.some(set => set.has(w) && !set.has(first)));
+  const second = independent?.[0] ?? ranked[1]?.[0];
+  return second ? [first, second] : null;
 }
 
 /**
@@ -83,10 +102,12 @@ async function probePortalParser(serverUrl: string): Promise<boolean> {
   const key = serverUrl.replace(/\/$/, '').toLowerCase();
   if (_portalParserCache.has(key)) return _portalParserCache.get(key)!;
 
-  let needsText = false;
   const terms = await pickProbeTerms(serverUrl).catch(() => null);
+  if (!terms) return false;   // could not measure: do not wrap, and do not remember
 
-  if (terms) {
+  let needsText = false;
+  let measured = false;
+  {
     const [a, b] = terms;
     const count = async (q: string): Promise<number | null> => {
       const res = await makeCkanRequest<any>(serverUrl, 'package_search', { q, rows: 0 })
@@ -103,10 +124,14 @@ async function probePortalParser(serverUrl: string): Promise<boolean> {
     if (ca !== null && cb !== null && cOr !== null && cText !== null) {
       const booleanIgnored = cOr < Math.max(ca, cb);
       needsText = booleanIgnored && cText > cOr;
+      measured = true;
     }
   }
 
-  _portalParserCache.set(key, needsText);
+  // A portal that timed out or errored must not be written off for the whole
+  // session: an unmeasured verdict is never cached, so the next boolean query on
+  // that portal tries again.
+  if (measured) _portalParserCache.set(key, needsText);
   return needsText;
 }
 
@@ -884,7 +909,10 @@ Typical workflow: ckan_status_show (check locale) → ckan_package_search (query
           const { effectiveQuery: strippedEffective } = resolveSearchQuery(
             params.server_url,
             strippedQuery,
-            params.query_parser
+            // parserOverride, not params.query_parser: the probe's verdict must
+            // survive the retry, or an accented boolean query is re-sent to the
+            // parser that ignores booleans.
+            parserOverride
           );
           const fallbackResult = await makeCkanRequest<any>(
             params.server_url,

--- a/src/tools/package.ts
+++ b/src/tools/package.ts
@@ -7,8 +7,8 @@ import { ResponseFormat, ResponseFormatSchema, CkanTag, CkanResource, CkanPackag
 import { makeCkanRequest, formatCkanError } from "../utils/http.js";
 import { truncateText, truncateJson, formatDate, formatBytes, addDemoFooter, wrapUntrusted, safeUrlText, formatError, jsonToolResult, sanitizeInline } from "../utils/formatting.js";
 import { getDatasetViewUrl, extractSourcePortal } from "../utils/url-generator.js";
-import { resolveSearchQuery, stripAccents, hasAccents, isPlainMultiTermQuery, buildOrQuery } from "../utils/search.js";
-import { getPortalHvdConfig, getPortalApiPath, requiresMultilingualNormalization, isPortalSearchExplicitlyConfigured } from "../utils/portal-config.js";
+import { resolveSearchQuery, stripAccents, hasAccents, isPlainMultiTermQuery, buildOrQuery, mayNeedTextWrapping } from "../utils/search.js";
+import { getPortalHvdConfig, getPortalApiPath, requiresMultilingualNormalization } from "../utils/portal-config.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 /**
@@ -19,25 +19,93 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 const _portalParserCache = new Map<string, boolean>();
 
 /**
- * Probe a portal to detect whether it needs force_text_field.
- * Runs two parallel rows=0 queries (default vs text parser) using "data OR dati".
- * If text count > default count * 2, the portal has the Solr df bug and needs wrapping.
- * Result is cached for the session lifetime.
+ * Pick two terms that actually occur in this catalog, for the parser probe below.
+ *
+ * They must be single words (a multi-word term would need quoting and change the
+ * parse) and neither rare nor saturating: a term matching most of the catalog makes
+ * `A OR B` indistinguishable from `A`, which is how the previous probe — hardcoded to
+ * "data OR dati" — read dati.comune.milano.it as healthy while `aria OR acqua` there
+ * returned 0 against 54 and 33 for the single terms.
+ *
+ * Tag facets first, since tags are in the catalog's own language; frequent title words
+ * as a fallback for portals that expose no tag facets (open.canada.ca) or too few
+ * (dati.regione.sicilia.it).
+ */
+async function pickProbeTerms(serverUrl: string): Promise<[string, string] | null> {
+  const facetRes = await makeCkanRequest<any>(serverUrl, 'package_search', {
+    q: '*:*',
+    rows: 0,
+    'facet.field': '["tags"]',
+    'facet.limit': 100
+  }).catch(() => null);
+
+  const total: number = facetRes?.count ?? 0;
+  if (!total) return null;
+
+  const items: Array<{ name?: string; count?: number }> =
+    facetRes?.search_facets?.tags?.items ?? [];
+  const usable = items
+    .filter(i => typeof i.name === 'string' && !/\s/.test(i.name))
+    .filter(i => (i.count ?? 0) >= total * 0.005 && (i.count ?? 0) <= total * 0.3)
+    .sort((a, b) => (b.count ?? 0) - (a.count ?? 0));
+  if (usable.length >= 2) return [usable[0].name!, usable[1].name!];
+
+  const sampleRes = await makeCkanRequest<any>(serverUrl, 'package_search', {
+    q: '*:*',
+    rows: 25
+  }).catch(() => null);
+  const titles: string[] = (sampleRes?.results ?? []).map((r: any) => r?.title ?? '');
+  const freq = new Map<string, number>();
+  for (const word of titles.join(' ').toLowerCase().split(/[^\p{L}]+/u)) {
+    if (word.length > 4) freq.set(word, (freq.get(word) ?? 0) + 1);
+  }
+  const top = [...freq.entries()].sort((a, b) => b[1] - a[1]).slice(0, 2);
+  return top.length === 2 ? [top[0][0], top[1][0]] : null;
+}
+
+/**
+ * Does this portal need `text:(...)` wrapping to honour a boolean query?
+ *
+ * `package_search` hands a colon-free query to Solr's dismax parser with `q.op=AND`
+ * (ckan/lib/search/query.py), and dismax has no boolean syntax: `A OR B` collapses to
+ * `A AND B`. A colon takes the query off dismax, which is what the wrapper exploits.
+ * That is CKAN's own default, so most portals need it — but not all: on
+ * data.stadt-zuerich.ch the catch-all `text` field returns 0 for every query, and
+ * wrapping there loses everything.
+ *
+ * So: an `A OR B` that returns fewer hits than `A` or `B` alone is not being honoured,
+ * and the wrapper is the fix only if the wrapped form actually returns more.
+ * Four rows=0 counts, cached per portal for the session, negative verdicts included.
+ * Callers must only reach here for queries that carry a boolean operator — nothing
+ * else is ever wrapped, so nothing else needs to pay for this.
  */
 async function probePortalParser(serverUrl: string): Promise<boolean> {
   const key = serverUrl.replace(/\/$/, '').toLowerCase();
   if (_portalParserCache.has(key)) return _portalParserCache.get(key)!;
 
-  const probe = 'data OR dati';
-  const [defaultRes, textRes] = await Promise.allSettled([
-    makeCkanRequest<any>(serverUrl, 'package_search', { q: probe, rows: 0 }),
-    makeCkanRequest<any>(serverUrl, 'package_search', { q: `text:(${probe})`, rows: 0 })
-  ]);
+  let needsText = false;
+  const terms = await pickProbeTerms(serverUrl).catch(() => null);
 
-  const defaultCount = defaultRes.status === 'fulfilled' ? (defaultRes.value.count ?? 0) : 0;
-  const textCount = textRes.status === 'fulfilled' ? (textRes.value.count ?? 0) : 0;
+  if (terms) {
+    const [a, b] = terms;
+    const count = async (q: string): Promise<number | null> => {
+      const res = await makeCkanRequest<any>(serverUrl, 'package_search', { q, rows: 0 })
+        .catch(() => null);
+      return typeof res?.count === 'number' ? res.count : null;
+    };
+    const [ca, cb, cOr, cText] = await Promise.all([
+      count(a),
+      count(b),
+      count(`${a} OR ${b}`),
+      count(`text:(${a} OR ${b})`)
+    ]);
 
-  const needsText = textCount > 0 && (defaultCount === 0 || textCount > defaultCount * 2);
+    if (ca !== null && cb !== null && cOr !== null && cText !== null) {
+      const booleanIgnored = cOr < Math.max(ca, cb);
+      needsText = booleanIgnored && cText > cOr;
+    }
+  }
+
   _portalParserCache.set(key, needsText);
   return needsText;
 }
@@ -773,10 +841,11 @@ Typical workflow: ckan_status_show (check locale) → ckan_package_search (query
           if (!effectiveSort) effectiveSort = "issued desc, metadata_created desc";
         }
 
-        // For portals not explicitly configured in portals.json, auto-detect
-        // whether they need text:(...) wrapping by probing with a two-term OR query.
+        // Only a boolean query can benefit from text:(...) wrapping, so only a boolean
+        // query pays for the probe. Every portal is probed, configured ones included:
+        // the values that used to live in portals.json went stale.
         let parserOverride = params.query_parser;
-        if (!parserOverride && !isPortalSearchExplicitlyConfigured(params.server_url)) {
+        if (!parserOverride && mayNeedTextWrapping(query)) {
           const needsText = await probePortalParser(params.server_url);
           if (needsText) parserOverride = "text";
         }
@@ -922,7 +991,10 @@ ${hvdNote}`;
           markdown += `No datasets found matching your query.\n`;
           markdown += `\n> **Note**: No data was found on this portal. Do not use information from other sources to supplement this result.\n`;
           if (isPlainMultiTermQuery(params.q)) {
-            markdown += `\n> **Tip**: Multi-term queries use AND by default (all terms must match). Try OR to broaden the search:\n`;
+            // CKAN's dismax applies mm='2<-1 5<80%', so a plain multi-term query is
+            // already a partial match: spelling out OR relaxes it the rest of the way
+            // and, on portals that ignore boolean operators, switches parser too.
+            markdown += `\n> **Tip**: With several terms the portal requires most of them to match. Spelling out OR broadens the search:\n`;
             markdown += `> \`q: "${buildOrQuery(params.q)}"\`\n`;
           }
         }

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -70,24 +70,46 @@ export function escapeSolrQuery(query: string): string {
   return query.replace(SOLR_SPECIAL_CHARS, "\\$&");
 }
 
+/** Parentheses that pair up can be trusted as grouping rather than stray input. */
+function hasBalancedParens(query: string): boolean {
+  let depth = 0;
+  for (const char of query) {
+    if (char === "(") depth++;
+    else if (char === ")" && --depth < 0) return false;
+  }
+  return depth === 0;
+}
+
 /**
- * Escape for `text:(...)` wrapping, leaving a `+`/`-`/`!` in operator position alone.
+ * Escape for `text:(...)` wrapping, keeping the syntax the caller actually meant.
  *
- * Escaping those inverts the caller's intent: on dati.gov.it `ambiente` returns 8047
- * and `ambiente -rifiuti` returns 7649, but `text:(ambiente \-rifiuti)` returns 398 —
- * exactly the 398 the caller asked to leave out. Unescaped, `text:(ambiente -rifiuti)`
- * returns 7649, the same answer dismax gives.
+ * A `+`/`-`/`!` in operator position stays: escaping it inverts the caller's intent.
+ * On dati.gov.it `ambiente` returns 8047 and `ambiente -rifiuti` returns 7649, but
+ * `text:(ambiente \-rifiuti)` returns 398 — exactly the 398 the caller asked to leave
+ * out. Unescaped, `text:(ambiente -rifiuti)` returns 7649, the same answer dismax
+ * gives, which is what lets a mixed query keep both halves: `text:(aria OR acqua
+ * -rifiuti)` returns 1349 against 1389 for the disjunction alone.
  *
- * Which is what lets a mixed query keep both halves: `text:(aria OR acqua -rifiuti)`
- * returns 1349 against 1389 for the disjunction alone, so the OR is honoured and the
- * exclusion applied. dismax gives 21 for the same disjunction, having swallowed the OR.
+ * Balanced parentheses stay too, since escaping turns grouping into literal tokens.
+ * On `(aria OR "qualità dell'aria") AND Milano`, a real query from the telemetry:
+ * dismax returns 0, escaped parentheses return 51, and preserved ones 59. Unbalanced
+ * parentheses are escaped as before — stray input must not become a syntax error.
  */
 export function escapeForTextWrapping(query: string): string {
+  const keepGroups = hasBalancedParens(query);
+
   return query.replace(
     SOLR_SPECIAL_CHARS,
     (char, offset: number, whole: string) => {
+      if (keepGroups && (char === "(" || char === ")")) return char;
+
       const isUnary = char === "+" || char === "-" || char === "!";
-      const atTermStart = offset === 0 || /\s/.test(whole[offset - 1]!);
+      const previous = offset === 0 ? "" : whole[offset - 1]!;
+      // A group opener is a term boundary as much as a space is, but only when the
+      // parenthesis itself survives: after an escaped one the operator would bind to
+      // the backslash.
+      const atTermStart =
+        offset === 0 || /\s/.test(previous) || (keepGroups && previous === "(");
       const followedByTerm = offset + 1 < whole.length && !/\s/.test(whole[offset + 1]!);
       return isUnary && atTermStart && followedByTerm ? char : `\\${char}`;
     }

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -7,8 +7,6 @@ const FIELD_QUERY_PATTERN = /\b[a-zA-Z_][\w-]*:/;
 const EXPLICIT_BOOL_PATTERN = /\b(AND|OR|NOT)\b|[+\-!]/;
 /** AND/OR/NOT: dismax has no syntax for these and swallows them. */
 const BOOL_KEYWORD_PATTERN = /\b(AND|OR|NOT)\b/;
-/** `+`/`-`/`!` in operator position — dismax honours these natively. */
-const UNARY_OPERATOR_PATTERN = /(^|\s)[+\-!]\S/;
 /** The same characters inside a word: `e-government`, `COVID-19`. */
 const INTRAWORD_PUNCT_PATTERN = /\S[+\-!]\S/;
 const SOLR_SPECIAL_CHARS = /[+\-!(){}[\]^~*?:\\/|&]/g;
@@ -41,14 +39,10 @@ function isFieldedQuery(query: string): boolean {
 export function hasExplicitBooleanOperator(query: string): boolean {
   const trimmed = query.trim();
 
-  // A `+`/`-`/`!` in operator position is the one thing dismax does handle, and
-  // wrapping would destroy it: `escapeSolrQuery` escapes the character, so
-  // `ambiente -rifiuti` becomes `text:(ambiente \-rifiuti)` and stops excluding —
-  // it starts requiring. Measured on dati.gov.it: `ambiente` 8047, `ambiente
-  // -rifiuti` 7649 unwrapped, 398 wrapped, and 8047 - 7649 = 398, i.e. exactly the
-  // set the caller asked to leave out. So leave these queries alone, keywords or not.
-  if (UNARY_OPERATOR_PATTERN.test(trimmed)) return false;
-
+  // dismax already honours a `+`/`-`/`!` in operator position, so a query carrying
+  // nothing else has no reason to pay for a probe — `escapeForTextWrapping` keeps
+  // those characters intact, so a mixed query like `aria OR acqua -rifiuti` can be
+  // wrapped without losing the exclusion.
   if (BOOL_KEYWORD_PATTERN.test(trimmed)) return true;
 
   // The same characters inside a word are not operators to the caller but are to
@@ -74,6 +68,30 @@ export function mayNeedTextWrapping(query: string): boolean {
 
 export function escapeSolrQuery(query: string): string {
   return query.replace(SOLR_SPECIAL_CHARS, "\\$&");
+}
+
+/**
+ * Escape for `text:(...)` wrapping, leaving a `+`/`-`/`!` in operator position alone.
+ *
+ * Escaping those inverts the caller's intent: on dati.gov.it `ambiente` returns 8047
+ * and `ambiente -rifiuti` returns 7649, but `text:(ambiente \-rifiuti)` returns 398 —
+ * exactly the 398 the caller asked to leave out. Unescaped, `text:(ambiente -rifiuti)`
+ * returns 7649, the same answer dismax gives.
+ *
+ * Which is what lets a mixed query keep both halves: `text:(aria OR acqua -rifiuti)`
+ * returns 1349 against 1389 for the disjunction alone, so the OR is honoured and the
+ * exclusion applied. dismax gives 21 for the same disjunction, having swallowed the OR.
+ */
+export function escapeForTextWrapping(query: string): string {
+  return query.replace(
+    SOLR_SPECIAL_CHARS,
+    (char, offset: number, whole: string) => {
+      const isUnary = char === "+" || char === "-" || char === "!";
+      const atTermStart = offset === 0 || /\s/.test(whole[offset - 1]!);
+      const followedByTerm = offset + 1 < whole.length && !/\s/.test(whole[offset + 1]!);
+      return isUnary && atTermStart && followedByTerm ? char : `\\${char}`;
+    }
+  );
 }
 
 /**
@@ -161,7 +179,7 @@ export function resolveSearchQuery(
       hasExplicitBooleanOperator(trimmedQuery);
   }
 
-  let effectiveQuery = forceTextField ? `text:(${escapeSolrQuery(query)})` : query;
+  let effectiveQuery = forceTextField ? `text:(${escapeForTextWrapping(query)})` : query;
   effectiveQuery = convertDateMathForUnsupportedFields(effectiveQuery);
 
   return { effectiveQuery, forcedTextField: forceTextField };

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -70,12 +70,23 @@ export function escapeSolrQuery(query: string): string {
   return query.replace(SOLR_SPECIAL_CHARS, "\\$&");
 }
 
-/** Parentheses that pair up can be trusted as grouping rather than stray input. */
+/** True when the parenthesis at `offset` was escaped by the caller, so it is a literal. */
+function isEscaped(query: string, offset: number): boolean {
+  let backslashes = 0;
+  for (let i = offset - 1; i >= 0 && query[i] === "\\"; i--) backslashes++;
+  return backslashes % 2 === 1;
+}
+
+/**
+ * Parentheses that pair up can be trusted as grouping rather than stray input.
+ * Escaped ones are the caller asking for the character itself and do not count.
+ */
 function hasBalancedParens(query: string): boolean {
   let depth = 0;
-  for (const char of query) {
-    if (char === "(") depth++;
-    else if (char === ")" && --depth < 0) return false;
+  for (let i = 0; i < query.length; i++) {
+    if (isEscaped(query, i)) continue;
+    if (query[i] === "(") depth++;
+    else if (query[i] === ")" && --depth < 0) return false;
   }
   return depth === 0;
 }
@@ -93,7 +104,8 @@ function hasBalancedParens(query: string): boolean {
  * Balanced parentheses stay too, since escaping turns grouping into literal tokens.
  * On `(aria OR "qualità dell'aria") AND Milano`, a real query from the telemetry:
  * dismax returns 0, escaped parentheses return 51, and preserved ones 59. Unbalanced
- * parentheses are escaped as before — stray input must not become a syntax error.
+ * parentheses are escaped as before — stray input must not become a syntax error, and
+ * a parenthesis the caller escaped is a literal, not a group.
  */
 export function escapeForTextWrapping(query: string): string {
   const keepGroups = hasBalancedParens(query);
@@ -101,7 +113,9 @@ export function escapeForTextWrapping(query: string): string {
   return query.replace(
     SOLR_SPECIAL_CHARS,
     (char, offset: number, whole: string) => {
-      if (keepGroups && (char === "(" || char === ")")) return char;
+      if (keepGroups && (char === "(" || char === ")") && !isEscaped(whole, offset)) {
+        return char;
+      }
 
       const isUnary = char === "+" || char === "-" || char === "!";
       const previous = offset === 0 ? "" : whole[offset - 1]!;

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -4,10 +4,51 @@ export type QueryParserOverride = "default" | "text" | undefined;
 
 const DEFAULT_SEARCH_QUERY = "*:*";
 const FIELD_QUERY_PATTERN = /\b[a-zA-Z_][\w-]*:/;
+const EXPLICIT_BOOL_PATTERN = /\b(AND|OR|NOT)\b|[+\-!]/;
 const SOLR_SPECIAL_CHARS = /[+\-!(){}[\]^~*?:\\/|&]/g;
 
 function isFieldedQuery(query: string): boolean {
   return FIELD_QUERY_PATTERN.test(query);
+}
+
+/**
+ * True when the query asks for boolean semantics: the AND/OR/NOT keywords, or a
+ * leading +/-/! operator. This is the only case where `text:(...)` wrapping earns
+ * its keep.
+ *
+ * Why: `package_search` sends a colon-free query to Solr's **dismax** parser with
+ * `q.op=AND`, `mm='2<-1 5<80%'` and `qf='name^4 title^4 tags^2 groups^2 text'`
+ * (ckan/lib/search/query.py). dismax has no boolean syntax, so `OR` is swallowed
+ * and `q.op=AND` takes over: on dati.gov.it `aria OR Milano` returns 59 results,
+ * exactly what `aria AND Milano` returns. A colon in the query makes CKAN leave
+ * dismax, which is what the wrapper exploits — `text:(aria OR Milano)` returns 3421.
+ *
+ * The same switch is what makes the wrapper harmful everywhere else: it drops the
+ * `qf` boosts that put titles and tags first, searches the catch-all `text` field
+ * alone, and ANDs every term instead of applying `mm`. `defibrillatori Comune di
+ * Lecce` goes from 678 results to 1, `musei roma arte opere catalogo` from 9 to 0.
+ *
+ * Measured 2026-09-05 on 40 real queries from the public deployment's telemetry:
+ * with a boolean operator the wrapper helped 8 times and hurt none; without one it
+ * helped none and hurt 10, six of them down to zero results.
+ */
+export function hasExplicitBooleanOperator(query: string): boolean {
+  return EXPLICIT_BOOL_PATTERN.test(query.trim());
+}
+
+/**
+ * True when wrapping could still change this query's meaning: it is not `*:*`, it is
+ * not already fielded (a colon has taken it off dismax on its own), and it carries a
+ * boolean operator. Everything else is left to the portal's own parser, so it must not
+ * pay for the probe either.
+ */
+export function mayNeedTextWrapping(query: string): boolean {
+  const trimmed = query.trim();
+  return (
+    trimmed !== DEFAULT_SEARCH_QUERY &&
+    !isFieldedQuery(trimmed) &&
+    hasExplicitBooleanOperator(trimmed)
+  );
 }
 
 export function escapeSolrQuery(query: string): string {
@@ -54,7 +95,6 @@ export function convertDateMathForUnsupportedFields(query: string): string {
   });
 }
 
-const EXPLICIT_BOOL_PATTERN = /\b(AND|OR|NOT)\b|[+\-!]/;
 
 export function isPlainMultiTermQuery(query: string): boolean {
   const trimmed = query.trim();
@@ -94,7 +134,10 @@ export function resolveSearchQuery(
     forceTextField = false;
   } else if (portalForce) {
     const trimmedQuery = query.trim();
-    forceTextField = trimmedQuery !== DEFAULT_SEARCH_QUERY && !isFieldedQuery(trimmedQuery);
+    forceTextField =
+      trimmedQuery !== DEFAULT_SEARCH_QUERY &&
+      !isFieldedQuery(trimmedQuery) &&
+      hasExplicitBooleanOperator(trimmedQuery);
   }
 
   let effectiveQuery = forceTextField ? `text:(${escapeSolrQuery(query)})` : query;

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -5,6 +5,12 @@ export type QueryParserOverride = "default" | "text" | undefined;
 const DEFAULT_SEARCH_QUERY = "*:*";
 const FIELD_QUERY_PATTERN = /\b[a-zA-Z_][\w-]*:/;
 const EXPLICIT_BOOL_PATTERN = /\b(AND|OR|NOT)\b|[+\-!]/;
+/** AND/OR/NOT: dismax has no syntax for these and swallows them. */
+const BOOL_KEYWORD_PATTERN = /\b(AND|OR|NOT)\b/;
+/** `+`/`-`/`!` in operator position — dismax honours these natively. */
+const UNARY_OPERATOR_PATTERN = /(^|\s)[+\-!]\S/;
+/** The same characters inside a word: `e-government`, `COVID-19`. */
+const INTRAWORD_PUNCT_PATTERN = /\S[+\-!]\S/;
 const SOLR_SPECIAL_CHARS = /[+\-!(){}[\]^~*?:\\/|&]/g;
 
 function isFieldedQuery(query: string): boolean {
@@ -33,7 +39,22 @@ function isFieldedQuery(query: string): boolean {
  * helped none and hurt 10, six of them down to zero results.
  */
 export function hasExplicitBooleanOperator(query: string): boolean {
-  return EXPLICIT_BOOL_PATTERN.test(query.trim());
+  const trimmed = query.trim();
+
+  // A `+`/`-`/`!` in operator position is the one thing dismax does handle, and
+  // wrapping would destroy it: `escapeSolrQuery` escapes the character, so
+  // `ambiente -rifiuti` becomes `text:(ambiente \-rifiuti)` and stops excluding —
+  // it starts requiring. Measured on dati.gov.it: `ambiente` 8047, `ambiente
+  // -rifiuti` 7649 unwrapped, 398 wrapped, and 8047 - 7649 = 398, i.e. exactly the
+  // set the caller asked to leave out. So leave these queries alone, keywords or not.
+  if (UNARY_OPERATOR_PATTERN.test(trimmed)) return false;
+
+  if (BOOL_KEYWORD_PATTERN.test(trimmed)) return true;
+
+  // The same characters inside a word are not operators to the caller but are to
+  // dismax, which reads `e-government` as `e` NOT `government`: 58919 of ~65000
+  // datasets, against 278 for the escaped literal. `COVID-19`: 9963 against 69.
+  return INTRAWORD_PUNCT_PATTERN.test(trimmed);
 }
 
 /**

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -323,6 +323,12 @@ describe('escapeForTextWrapping', () => {
     expect(escapeForTextWrapping('aria OR (-rifiuti)')).toBe('aria OR (-rifiuti)');
   });
 
+  it('leaves a parenthesis the caller escaped as a literal', () => {
+    // Promoting it to grouping would change the query the caller wrote, and the
+    // doubled backslash would leave a stray character behind.
+    expect(escapeForTextWrapping('foo OR \\(bar\\)')).toBe('foo OR \\\\\\(bar\\\\\\)');
+  });
+
   it('escapes unbalanced parentheses: stray input must not become a syntax error', () => {
     expect(escapeForTextWrapping('foo (bar')).toBe('foo \\(bar');
     expect(escapeForTextWrapping('foo bar)')).toBe('foo bar\\)');

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -313,8 +313,24 @@ describe('escapeForTextWrapping', () => {
     expect(escapeForTextWrapping('ambiente - rifiuti')).toBe('ambiente \\- rifiuti');
   });
 
+  it('keeps balanced grouping parentheses', () => {
+    // `(aria OR "qualità dell'aria") AND Milano`, a real query from the telemetry:
+    // dismax returns 0, escaped parentheses 51, preserved ones 59.
+    expect(escapeForTextWrapping('(aria OR acqua) AND Milano')).toBe('(aria OR acqua) AND Milano');
+  });
+
+  it('treats a group opener as a term boundary', () => {
+    expect(escapeForTextWrapping('aria OR (-rifiuti)')).toBe('aria OR (-rifiuti)');
+  });
+
+  it('escapes unbalanced parentheses: stray input must not become a syntax error', () => {
+    expect(escapeForTextWrapping('foo (bar')).toBe('foo \\(bar');
+    expect(escapeForTextWrapping('foo bar)')).toBe('foo bar\\)');
+    expect(escapeForTextWrapping('foo )bar( baz')).toBe('foo \\)bar\\( baz');
+  });
+
   it('escapes every other special character as before', () => {
-    expect(escapeForTextWrapping('foo (bar):baz')).toBe(escapeSolrQuery('foo (bar):baz'));
+    expect(escapeForTextWrapping('foo bar:baz')).toBe(escapeSolrQuery('foo bar:baz'));
   });
 
   it('wraps a mixed query without losing the exclusion', () => {

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveSearchQuery, escapeSolrQuery, convertDateMathForUnsupportedFields, stripAccents, hasAccents, isPlainMultiTermQuery, buildOrQuery, hasExplicitBooleanOperator, mayNeedTextWrapping } from '../../src/utils/search';
+import { resolveSearchQuery, escapeSolrQuery, escapeForTextWrapping, convertDateMathForUnsupportedFields, stripAccents, hasAccents, isPlainMultiTermQuery, buildOrQuery, hasExplicitBooleanOperator, mayNeedTextWrapping } from '../../src/utils/search';
 
 describe('resolveSearchQuery', () => {
   it('keeps query unchanged for non-configured portals', () => {
@@ -280,20 +280,50 @@ describe('hasExplicitBooleanOperator', () => {
     expect(hasExplicitBooleanOperator('COVID-19')).toBe(true);
   });
 
-  it('leaves a real unary operator alone: wrapping inverts it', () => {
-    // dati.gov.it: `ambiente` 8047, `ambiente -rifiuti` 7649 unwrapped and 398
-    // wrapped — and 8047 - 7649 = 398, exactly the set the caller excluded.
-    // dismax honours +/-/! natively, so these queries must reach it untouched.
+  it('does not probe for a unary operator alone: dismax already honours it', () => {
+    // dati.gov.it: `ambiente` 8047, `ambiente -rifiuti` 7649 — the exclusion works,
+    // so there is nothing to repair and no reason to pay for a probe.
     expect(hasExplicitBooleanOperator('ambiente -rifiuti')).toBe(false);
     expect(hasExplicitBooleanOperator('+ambiente +rifiuti')).toBe(false);
     expect(hasExplicitBooleanOperator('ambiente !rifiuti')).toBe(false);
     expect(mayNeedTextWrapping('ambiente -rifiuti')).toBe(false);
   });
 
-  it('prefers a typed exclusion over the OR fix when both are present', () => {
-    // Neither form serves both: wrapping restores OR but destroys the exclusion.
-    // The exclusion was typed explicitly and the portal can honour it, so it wins.
-    expect(hasExplicitBooleanOperator('aria OR acqua -rifiuti')).toBe(false);
+  it('keeps both halves of a mixed query', () => {
+    // `text:(aria OR acqua -rifiuti)` returns 1349 against 1389 for the disjunction
+    // alone: the OR is honoured and the exclusion applied. dismax returns 21.
+    expect(hasExplicitBooleanOperator('aria OR acqua -rifiuti')).toBe(true);
+  });
+});
+
+describe('escapeForTextWrapping', () => {
+  it('leaves a unary operator in operator position intact', () => {
+    // Escaping it inverts the query: text:(ambiente \-rifiuti) returns 398, exactly
+    // the set the caller excluded, against 7649 for the unescaped form.
+    expect(escapeForTextWrapping('ambiente -rifiuti')).toBe('ambiente -rifiuti');
+    expect(escapeForTextWrapping('+ambiente -rifiuti')).toBe('+ambiente -rifiuti');
+  });
+
+  it('still escapes the same characters inside a word', () => {
+    expect(escapeForTextWrapping('e-government')).toBe('e\\-government');
+    expect(escapeForTextWrapping('COVID-19')).toBe('COVID\\-19');
+  });
+
+  it('escapes a dangling operator, which is not one', () => {
+    expect(escapeForTextWrapping('ambiente - rifiuti')).toBe('ambiente \\- rifiuti');
+  });
+
+  it('escapes every other special character as before', () => {
+    expect(escapeForTextWrapping('foo (bar):baz')).toBe(escapeSolrQuery('foo (bar):baz'));
+  });
+
+  it('wraps a mixed query without losing the exclusion', () => {
+    const result = resolveSearchQuery(
+      'https://www.dati.gov.it/opendata',
+      'aria OR acqua -rifiuti',
+      'text'
+    );
+    expect(result.effectiveQuery).toBe('text:(aria OR acqua -rifiuti)');
   });
 });
 

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -273,10 +273,27 @@ describe('hasExplicitBooleanOperator', () => {
     expect(hasExplicitBooleanOperator(query as string)).toBe(expected);
   });
 
-  it('treats a hyphenated term as an operator, which is what the portal does', () => {
-    // plain e-government returns 58919 of ~65000 datasets: the portal reads the
-    // hyphen as NOT. The wrapper gives 278 instead.
+  it('wraps intra-word punctuation, which dismax misreads as an operator', () => {
+    // plain `e-government` returns 58919 of ~65000 datasets — the portal reads the
+    // hyphen as NOT — against 278 for the escaped literal. `COVID-19`: 9963 vs 69.
     expect(hasExplicitBooleanOperator('e-government')).toBe(true);
+    expect(hasExplicitBooleanOperator('COVID-19')).toBe(true);
+  });
+
+  it('leaves a real unary operator alone: wrapping inverts it', () => {
+    // dati.gov.it: `ambiente` 8047, `ambiente -rifiuti` 7649 unwrapped and 398
+    // wrapped — and 8047 - 7649 = 398, exactly the set the caller excluded.
+    // dismax honours +/-/! natively, so these queries must reach it untouched.
+    expect(hasExplicitBooleanOperator('ambiente -rifiuti')).toBe(false);
+    expect(hasExplicitBooleanOperator('+ambiente +rifiuti')).toBe(false);
+    expect(hasExplicitBooleanOperator('ambiente !rifiuti')).toBe(false);
+    expect(mayNeedTextWrapping('ambiente -rifiuti')).toBe(false);
+  });
+
+  it('prefers a typed exclusion over the OR fix when both are present', () => {
+    // Neither form serves both: wrapping restores OR but destroys the exclusion.
+    // The exclusion was typed explicitly and the portal can honour it, so it wins.
+    expect(hasExplicitBooleanOperator('aria OR acqua -rifiuti')).toBe(false);
   });
 });
 

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveSearchQuery, escapeSolrQuery, convertDateMathForUnsupportedFields, stripAccents, hasAccents, isPlainMultiTermQuery, buildOrQuery } from '../../src/utils/search';
+import { resolveSearchQuery, escapeSolrQuery, convertDateMathForUnsupportedFields, stripAccents, hasAccents, isPlainMultiTermQuery, buildOrQuery, hasExplicitBooleanOperator, mayNeedTextWrapping } from '../../src/utils/search';
 
 describe('resolveSearchQuery', () => {
   it('keeps query unchanged for non-configured portals', () => {
@@ -13,11 +13,11 @@ describe('resolveSearchQuery', () => {
     expect(result.forcedTextField).toBe(false);
   });
 
-  it('forces text field for configured portals on non-fielded queries', () => {
+  it('wraps a boolean query when the probe asked for the text parser', () => {
     const result = resolveSearchQuery(
       'https://www.dati.gov.it/opendata',
       'hotel OR alberghi',
-      undefined
+      'text'
     );
 
     expect(result.effectiveQuery).toBe('text:(hotel OR alberghi)');
@@ -83,21 +83,25 @@ describe('resolveSearchQuery', () => {
     const escaped = escapeSolrQuery('foo") (bar):baz\\qux');
     expect(escaped).toBe('foo"\\) \\(bar\\)\\:baz\\\\qux');
 
+    // The wrapping only applies to boolean queries now, so the escaping path is
+    // exercised through one.
     const result = resolveSearchQuery(
       'https://www.dati.gov.it/opendata',
-      'foo") (bar):baz\\qux',
-      undefined
+      'foo") (bar):baz\\qux OR altro',
+      'text'
     );
 
-    expect(result.effectiveQuery).toBe('text:(foo"\\) \\(bar\\)\\:baz\\\\qux)');
     expect(result.forcedTextField).toBe(true);
+    expect(result.effectiveQuery).toContain('text:(');
+    expect(result.effectiveQuery).toContain('OR altro');
+    expect(result.effectiveQuery).toContain('\\(bar');
   });
 
   it('preserves quoted phrases inside text:() wrapping', () => {
     const result = resolveSearchQuery(
       'https://www.dati.gov.it/opendata',
       'SIC OR PAI OR "aree protette" OR "rischio idrogeologico"',
-      undefined
+      'text'
     );
 
     expect(result.effectiveQuery).toBe('text:(SIC OR PAI OR "aree protette" OR "rischio idrogeologico")');
@@ -249,5 +253,94 @@ describe('buildOrQuery', () => {
 
   it('handles extra whitespace', () => {
     expect(buildOrQuery('  crime   homicide  ')).toBe('crime OR homicide');
+  });
+});
+
+describe('hasExplicitBooleanOperator', () => {
+  // The shapes below were measured against live portals on 2026-09-05. Counts are
+  // dati.gov.it, plain vs text:(...): the wrapper must reach only the boolean ones.
+  it.each([
+    ['ambiente', false],                              // 8047 / 8047
+    ['qualità aria', false],                          // 366 / 366
+    ['qualità aria Milano', false],                   // 650 / 51
+    ['defibrillatori Comune di Lecce', false],        // 678 / 1
+    ['musei roma arte opere catalogo', false],        // 9 / 0
+    ['"qualità dell\'aria"', false],                  // 318 / 318
+    ['aria OR Milano', true],                         // 59 / 3421
+    ['aria AND Milano', true],                        // 59 / 59
+    ['bandiera blu OR bandiere blu OR spiagge', true] // 0 / 7
+  ])('%s -> %s', (query, expected) => {
+    expect(hasExplicitBooleanOperator(query as string)).toBe(expected);
+  });
+
+  it('treats a hyphenated term as an operator, which is what the portal does', () => {
+    // plain e-government returns 58919 of ~65000 datasets: the portal reads the
+    // hyphen as NOT. The wrapper gives 278 instead.
+    expect(hasExplicitBooleanOperator('e-government')).toBe(true);
+  });
+});
+
+describe('mayNeedTextWrapping', () => {
+  it('is false for the match-all query, so it never triggers a probe', () => {
+    expect(mayNeedTextWrapping('*:*')).toBe(false);
+  });
+
+  it('is false for a fielded query: the colon already leaves dismax', () => {
+    expect(mayNeedTextWrapping('title:(aria OR acqua)')).toBe(false);
+    expect(mayNeedTextWrapping('metadata_created:[NOW-7DAYS TO NOW]')).toBe(false);
+  });
+
+  it('is false for plain keyword queries, the common LLM-generated shape', () => {
+    expect(mayNeedTextWrapping('bonifica siti contaminati Piemonte')).toBe(false);
+    expect(mayNeedTextWrapping('ANAC bandi gara appalti OCDS anticorruzione')).toBe(false);
+  });
+
+  it('is true only when a boolean operator can actually be honoured', () => {
+    expect(mayNeedTextWrapping('aria OR acqua')).toBe(true);
+  });
+});
+
+describe('resolveSearchQuery — boolean-only wrapping', () => {
+  it('leaves a plain multi-term query to the portal parser', () => {
+    // The regression this guards: 678 results collapsed to 1. Two layers keep it
+    // away: mayNeedTextWrapping stops the probe from ever asking for the wrapper on
+    // this shape, and with no override nothing wraps.
+    expect(mayNeedTextWrapping('defibrillatori Comune di Lecce')).toBe(false);
+
+    const result = resolveSearchQuery(
+      'https://www.dati.gov.it/opendata',
+      'defibrillatori Comune di Lecce',
+      undefined
+    );
+    expect(result.forcedTextField).toBe(false);
+    expect(result.effectiveQuery).toBe('defibrillatori Comune di Lecce');
+  });
+
+  it('honours an explicit query_parser: "text" from the caller, whatever the shape', () => {
+    const result = resolveSearchQuery(
+      'https://www.dati.gov.it/opendata',
+      'defibrillatori Comune di Lecce',
+      'text'
+    );
+    expect(result.forcedTextField).toBe(true);
+  });
+
+  it('still wraps when the query carries OR', () => {
+    const result = resolveSearchQuery(
+      'https://www.dati.gov.it/opendata',
+      'bandiera blu OR spiagge',
+      'text'
+    );
+    expect(result.forcedTextField).toBe(true);
+    expect(result.effectiveQuery).toBe('text:(bandiera blu OR spiagge)');
+  });
+
+  it('never wraps when the caller asked for the default parser', () => {
+    const result = resolveSearchQuery(
+      'https://www.dati.gov.it/opendata',
+      'aria OR acqua',
+      'default'
+    );
+    expect(result.forcedTextField).toBe(false);
   });
 });


### PR DESCRIPTION
## What the telemetry showed

On 29 July an LLM client spent three hours reformulating the same request against `www.dati.gov.it/opendata`:

```
11:47  bonifica siti contaminati Piemonte
12:04  bonifica siti contaminati Piemonte
13:05  siti contaminati bonifica Piemonte
14:25  siti contaminati bonifica aree industriali dismesse brownfield amianto Piemonte
14:38  siti contaminati bonifica Gargallo Novara
```

The data was there from the first attempt. That query returns **22** datasets on the portal, the Piedmont contaminated-sites registry (ASCO) first. We were returning **5**.

## Why

`package_search` hands a colon-free query to Solr's **dismax** parser with `q.op=AND`, `mm='2<-1 5<80%'` and `qf='name^4 title^4 tags^2 groups^2 text'` (`ckan/lib/search/query.py`). dismax has no boolean syntax, so `A OR B` collapses into `A AND B` — on dati.gov.it `aria OR Milano` returns 59, exactly what `aria AND Milano` returns. A colon takes the query off dismax, which is what wrapping it as `text:(...)` exploits.

The same switch is why the wrapper hurts everything else: it drops the `qf` boosts that rank titles and tags first, searches the catch-all `text` field alone, and ANDs every term instead of applying `mm`.

This is CKAN's own default, not a defect of particular portals — which is why the same pattern shows up everywhere:

| portal | multi-word: plain → text | boolean: plain → text |
|---|---|---|
| dati.gov.it | 650 → 51 | 59 → 3421 |
| dati.comune.milano.it | 52 → 45 | 0 → 87 |
| dati.toscana.it | 14 → 1 | 2 → 339 |
| dati.regione.sicilia.it | 6 → 4 | 4 → 11 |
| data.gov.ua | 4215 → 353 | 2310 → 20571 |
| data.stadt-zuerich.ch | 172 → 0 | 10 → 0 |

On dati.gov.it: `defibrillatori Comune di Lecce` 678 → 1, `musei roma arte opere catalogo` 9 → **0** — the second most repeated query of the semester, answered with an empty page while nine datasets existed.

On 40 real queries from telemetry the separation is clean:

| | wrapper helps | wrapper hurts | no change |
|---|---|---|---|
| with `OR`/`AND`/`NOT` | 8 | 0 | 1 |
| without | 0 | 10 | 21 |

Six of the ten go to zero results.

## Changes

**The rule** (`src/utils/search.ts`) — the wrapper is reserved for the queries dismax cannot serve:

| query shape | wrapped | why |
|---|---|---|
| `bonifica siti contaminati Piemonte` | no | dismax ranks it across `qf` with `mm`; wrapping drops both |
| `aria OR Milano` | yes | dismax has no boolean syntax and `q.op=AND` swallows the OR |
| `ambiente -rifiuti` | no | dismax honours unary operators natively, so there is nothing to repair |
| `e-government`, `COVID-19` | yes | no operator to the caller, but dismax reads the hyphen as NOT: 58919 of ~65000 datasets against 278 for the escaped literal |
| `title:(aria OR acqua)` | no | the colon has already taken it off dismax |

An explicit `query_parser: "text"` from the caller stays a literal override.

**The escaping** (`escapeForTextWrapping`) — wrapping only helps if it preserves what the caller wrote. `escapeSolrQuery` escapes every special character, which inverts a unary operator: `text:(ambiente \-rifiuti)` returns 398 on dati.gov.it, exactly the set the caller excluded, against 7649 for the unescaped form. So a `+`/`-`/`!` in operator position and balanced grouping parentheses survive; everything else is escaped as before, including a parenthesis the caller escaped, which is a literal rather than a group.

This is what lets a mixed query keep both halves: `text:(aria OR acqua -rifiuti)` returns 1349 against 1389 for the disjunction alone, so the OR is honoured and the exclusion applied. dismax returns 21, having swallowed the OR. And on a real grouped query from the telemetry, `(aria OR "qualità dell'aria") AND Milano`: dismax 0, escaped parentheses 51, preserved 59.

**The probe** (`src/tools/package.ts`) — rewritten, and now run for every portal, configured ones included. `force_text_field` is gone from `portals.json` (8 entries) so there is one source of truth; the stored values had gone stale, with two portals marked "no wrapping" for a reason the rule now handles.

The old probe asked `data OR dati`, two words common enough to saturate: on Milano `data` alone and `data OR dati` both return 2564, so it read the portal as healthy while `aria OR acqua` returned 0 against 54 and 33 for the single terms. It now picks two terms from the catalog itself — single-word tag facets between 0.5% and 30%, falling back to frequent title words, restricted to letters, digits and underscore so no Solr syntax leaks into the probe — and compares `A`, `B`, `A OR B`, `text:(A OR B)`. An OR returning fewer hits than either operand is not being honoured, and the wrapper is the answer only if the wrapped form returns more. `data.stadt-zuerich.ch`, whose `text` field returns 0 for every query, is correctly left alone.

A verdict is cached only when it was actually measured, so a portal that times out or 500s is retried rather than written off for the session. The title fallback prefers a second term appearing where the first does not, since two words that always travel together make `A OR B` equal `A` even on a healthy portal.

**Cost** — a plain query pays nothing, since nothing but a boolean query can be wrapped. Measured from the audit log: 1 call for a plain search, 6 for the first boolean search on a portal (5 probe + 1 real), 1 afterwards.

## Verification

- 527 tests, 29 added
- e2e against live portals:

| query | before | after |
|---|---|---|
| `bonifica siti contaminati Piemonte` | 5 | 22, ASCO registry first |
| `musei roma arte opere catalogo` | 0 | 9 |
| `aria OR acqua` (Milano) | 0 | 87 |
| `ambiente -rifiuti` | 398, inverted | 7649, exclusion intact |
| `aria OR acqua -rifiuti` | 471 | 1349, both halves |
| `(aria OR acqua) AND Milano` | 39 | 98, grouping preserved |
| `e-government` | 278 | 278, unchanged |
| Zurich, boolean and plain | 10 / 172 | unchanged |

## Out of scope, found on the way

`catalog.data.gov` answers 404 on `package_search`, and `dati.arpae.it` is intermittent — 200 on one call, 500 on the next, wrapped or not. Both are configured portals and deserve their own issue. `data.gov.uk` is fine: it answers through its configured `/api/action` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEpSWpAwuMaGkfnMpQdqK2

