### PR TITLE
chore(release): v0.4.123

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -2,6 +2,10 @@
 
 ## 2026-09-05
 
+### v0.4.123 - relevance scoring and shared parser probe
+
+Ships #536: field scoring by share of matched terms, Italian stopwords with acronyms preserved, Unicode-aware term matching, a wider candidate window, the parser probe shared with `ckan_find_relevant_datasets`, and accent-safe filters in `ckan_organization_search` and `ckan_tag_list`. `openspec/specs/ckan-search/spec.md` rewritten around the query-building path.
+
 ### Relevance scoring: three defects that only became visible once search worked
 
 Testing v0.4.122 through an MCP client, not curl, showed `ckan_find_relevant_datasets`

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "dxt_version": "0.1",
   "name": "ckan-mcp-server",
-  "version": "0.4.122",
+  "version": "0.4.123",
   "display_name": "CKAN MCP Server",
   "description": "Explore open data portals based on CKAN (dati.gov.it, data.gov, open.canada.ca, ...)",
   "long_description": "MCP server for interacting with CKAN-based open data portals. Provides tools for advanced dataset search with Solr syntax, DataStore queries for tabular data analysis, organization and group exploration, and complete metadata access.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aborruso/ckan-mcp-server",
-  "version": "0.4.122",
+  "version": "0.4.123",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aborruso/ckan-mcp-server",
-      "version": "0.4.122",
+      "version": "0.4.123",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aborruso/ckan-mcp-server",
-  "version": "0.4.122",
+  "version": "0.4.123",
   "mcpName": "io.github.aborruso/ckan-mcp-server",
   "description": "MCP server for interacting with CKAN open data portals",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/ondata/ckan-mcp-server",
     "source": "github"
   },
-  "version": "0.4.122",
+  "version": "0.4.123",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aborruso/ckan-mcp-server",
-      "version": "0.4.122",
+      "version": "0.4.123",
       "transport": {
         "type": "stdio"
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,7 @@ import { registerAllPrompts } from "./prompts/index.js";
 export function createServer(): McpServer {
   return new McpServer({
     name: "ckan-mcp-server",
-    version: "0.4.122"
+    version: "0.4.123"
   });
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -220,7 +220,7 @@ export default {
     if (request.method === 'GET' && url.pathname === '/health') {
       return new Response(JSON.stringify({
         status: 'ok',
-        version: '0.4.122',
+        version: '0.4.123',
         tools: 20,
         resources: 7,
         prompts: 6,


### PR DESCRIPTION
Release for #536 — relevance scoring, the parser probe shared with `ckan_find_relevant_datasets`, and accent-safe filters.

## Version bump

`package.json`, `package-lock.json`, `manifest.json`, `server.json` (both fields), `src/server.ts`, `src/worker.ts`. No tools added or removed, so the `/health` count stays at 20.

```
$ grep -rn "0.4.122" package.json manifest.json server.json src/server.ts src/worker.ts
(nothing)
```

## Verification

- `npm run build` and `npm run build:worker`: ok
- `npm test`: 535 passed, 6 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEpSWpAwuMaGkfnMpQdqK2
