### PR TITLE
test(smoke): a release gate that asserts which dataset comes back

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,16 +210,16 @@ The server (`src/index.ts`):
    - `tools/datastore.ts`: `ckan_datastore_search`
    - `tools/status.ts`: `ckan_status_show`
 
-3. **MCP Resource Templates** (`resources/`)
+4. **MCP Resource Templates** (`resources/`)
    - `ckan://{server}/dataset/{id}` - Dataset metadata
    - `ckan://{server}/resource/{id}` - Resource metadata
    - `ckan://{server}/organization/{name}` - Organization metadata
 
-4. **Utility Functions** (`utils/`)
+5. **Utility Functions** (`utils/`)
    - `http.ts`: `makeCkanRequest<T>()` - HTTP client for CKAN API v3
    - `formatting.ts`: `truncateText()`, `formatDate()`, `formatBytes()`
 
-5. **Type Definitions** (`types.ts`)
+6. **Type Definitions** (`types.ts`)
    - `ResponseFormat` enum (MARKDOWN, JSON)
    - `ResponseFormatSchema` Zod validator
    - `CHARACTER_LIMIT` constant
@@ -228,11 +228,11 @@ The server (`src/index.ts`):
    - `stdio.ts`: Standard input/output (Claude Desktop)
    - `http.ts`: HTTP server (remote access)
 
-6. **Validation Schema**
+7. **Validation Schema**
    - Uses Zod to validate all tool inputs
    - Each tool has a strict schema that rejects extra parameters
 
-7. **Output Formatting**
+8. **Output Formatting**
    - All tools support two formats: `markdown` (default) and `json`
    - Markdown format optimized for human readability
    - JSON format returns compact objects with only essential fields (~70% token reduction vs raw CKAN API)
@@ -460,20 +460,21 @@ npm cannot resolve relative paths from the tarball.
 When releasing a new version:
 
 1. **Update version**: Edit the version field in `package.json`, `package-lock.json`, `manifest.json`, **`server.json`** (in `server.json` there are **two** fields: top-level `version` and `packages[0].version` — both must match), **`src/server.ts`** (MCP server version) and **`src/worker.ts`** (`/health` response). The two source files are easy to forget: v0.4.119 shipped with them still at 0.4.118. Check with `grep -rn "<old version>" package.json manifest.json server.json src/server.ts src/worker.ts` — it must return nothing
-2. **Update LOG.md**: Add entry with date and changes
-3. **Commit changes on a branch**: `git checkout -b <type>/<description>` then `git add . && git commit -m "..."`. Code never goes straight to `main`; documentation-only changes may.
-4. **Open a PR and merge it**: `git push -u origin <branch>`, `gh pr create`, wait for green checks, `gh pr merge --squash --delete-branch`, then `git checkout main && git pull`. `main` has a `non_fast_forward` rule: a commit pushed there by mistake needs a revert, not a force-push.
-5. **Create tag**: `git tag -a v0.x.0 -m "..." && git push origin v0.x.0` — ⚠️ **this triggers the npm publish**, see step 9
-6. **Build DXT**: `npm run pack:dxt` → produces `ckan-mcp-server.dxt`
-7. **Build skill**: `npm run pack:skill` → produces `tmp/ckan-mcp.skill`
-8. **Attach to release**: `gh release upload v0.x.0 ckan-mcp-server.dxt tmp/ckan-mcp.skill`
-9. **npm publish happens automatically**: pushing the tag in step 5 starts `.github/workflows/release.yml`, which verifies the tag matches `package.json`, builds, tests, and runs `npm publish --provenance`. **Do not run `npm publish` by hand** — the two paths collide and the loser gets `EPUBLISHCONFLICT`. Watch the run: `gh run watch $(gh run list --workflow=release.yml --limit 1 --json databaseId -q '.[0].databaseId')`
-10. **Publish to the MCP Registry** — only **after** the step 9 run has finished green, since the registry validates that the npm version exists: `mcp-publisher login github && mcp-publisher publish`. If login fails with `incorrect_device_code`, the local binary is stale: compare `mcp-publisher --version` against the [latest release](https://github.com/modelcontextprotocol/registry/releases) and update it — the device-auth flow has changed between versions, and the error does not say so
-11. **Deploy to Cloudflare** (if code changed): `npm run deploy`
+2. **Run the release gate**: `npm run smoke` — known-answer search queries against live portals, asserting *which* dataset comes back rather than how many. It must be green before tagging. It exists because v0.4.122 shipped with counts verified and ranking broken: "22 results" and "the right dataset first" are different claims
+3. **Update LOG.md**: Add entry with date and changes
+4. **Commit changes on a branch**: `git checkout -b <type>/<description>` then `git add . && git commit -m "..."`. Code never goes straight to `main`; documentation-only changes may.
+5. **Open a PR and merge it**: `git push -u origin <branch>`, `gh pr create`, wait for green checks, `gh pr merge --squash --delete-branch`, then `git checkout main && git pull`. `main` has a `non_fast_forward` rule: a commit pushed there by mistake needs a revert, not a force-push.
+6. **Create tag**: `git tag -a v0.x.0 -m "..." && git push origin v0.x.0` — ⚠️ **this triggers the npm publish**, see step 10
+7. **Build DXT**: `npm run pack:dxt` → produces `ckan-mcp-server.dxt`
+8. **Build skill**: `npm run pack:skill` → produces `tmp/ckan-mcp.skill`
+9. **Attach to release**: `gh release upload v0.x.0 ckan-mcp-server.dxt tmp/ckan-mcp.skill`
+10. **npm publish happens automatically**: pushing the tag in step 6 starts `.github/workflows/release.yml`, which verifies the tag matches `package.json`, builds, tests, and runs `npm publish --provenance`. **Do not run `npm publish` by hand** — the two paths collide and the loser gets `EPUBLISHCONFLICT`. Watch the run: `gh run watch $(gh run list --workflow=release.yml --limit 1 --json databaseId -q '.[0].databaseId')`
+11. **Publish to the MCP Registry** — only **after** the step 10 run has finished green, since the registry validates that the npm version exists: `mcp-publisher login github && mcp-publisher publish`. If login fails with `incorrect_device_code`, the local binary is stale: compare `mcp-publisher --version` against the [latest release](https://github.com/modelcontextprotocol/registry/releases) and update it — the device-auth flow has changed between versions, and the error does not say so
+12. **Deploy to Cloudflare** (if code changed): `npm run deploy`
 
 See `docs/DEPLOYMENT.md` for detailed Cloudflare deployment instructions.
 
-**Why steps 1 and 10 matter**: `server.json` feeds the official MCP Registry entry, which is what clients installing via the registry resolve. It is *not* updated by `npm publish`. Skipping it silently pins public installs to an old version: between v0.4.83 (2026-03-12) and v0.4.114 (2026-08-03) the registry advertised a build predating the v0.4.108 SSRF remediation, while npm was current. Verify after publishing:
+**Why steps 1 and 11 matter**: `server.json` feeds the official MCP Registry entry, which is what clients installing via the registry resolve. It is *not* updated by `npm publish`. Skipping it silently pins public installs to an old version: between v0.4.83 (2026-03-12) and v0.4.114 (2026-08-03) the registry advertised a build predating the v0.4.108 SSRF remediation, while npm was current. Verify after publishing:
 
 ```bash
 curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=io.github.aborruso/ckan-mcp-server" | \

--- a/LOG.md
+++ b/LOG.md
@@ -2,6 +2,39 @@
 
 ## 2026-09-05
 
+### A release gate that asserts which dataset comes back
+
+Three releases went out today, two of them to repair the one before. The verification in
+between was a sequence of commands rebuilt from memory each time, so it covered something
+different on each pass — and what it always covered was result counts. v0.4.122 shipped
+with counts verified and the ranking broken, because "22 results" and "the right dataset
+first" are different claims and only the second is what a caller asked for.
+
+`npm run smoke` is that check as a command. Twelve known-answer cases from real telemetry
+in `tests/smoke/cases.json`, each asserting which dataset must come back and carrying the
+regression it guards; the runner starts the built server over HTTP, calls each tool the
+way a client does, and exits non-zero on the first failure.
+
+Checked against the defects it claims to catch: reintroducing the v0.4.121 wrapping rule
+fails 4 of 12, and removing the parser probe from `ckan_find_relevant_datasets` — the
+v0.4.122 regression — fails the case requiring the two search tools to agree. Wired into
+the release workflow in `CLAUDE.md` (step 2, before the tag) and the checklist in
+`docs/DEPLOYMENT.md`.
+
+Two things the gate needed on the way:
+
+- the JSON format never exposed the query that actually ran, while Markdown has always
+  shown it. `effective_query` now appears in `ckan_package_search` JSON output when the
+  server rewrote the query, and is absent when it did not.
+- relevance scores summed unrounded fractions, printing totals like `8.299999999999999`.
+
+Known and not fixed: the ranking model weights every query term equally, so on
+`defibrillatori Comune di Lecce` three datasets tie at 9.7 and the right one leads on
+Solr order rather than on score. Making the `tags` field proportional like the others was
+tried and reverted — it promotes "Elenco patrocini Comune di Lecce", whose tags carry two
+of the three terms against the defibrillator dataset's one. The fix is term specificity,
+a design change, not a patch.
+
 ### v0.4.123 - relevance scoring and shared parser probe
 
 Ships #536: field scoring by share of matched terms, Italian stopwords with acronyms preserved, Unicode-aware term matching, a wider candidate window, the parser probe shared with `ckan_find_relevant_datasets`, and accent-safe filters in `ckan_organization_search` and `ckan_tag_list`. `openspec/specs/ckan-search/spec.md` rewritten around the query-building path.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -651,6 +651,10 @@ Verify:
 Use this checklist to ensure nothing is missed:
 
 ### Pre-Release
+- [ ] **Release gate green**: `npm run smoke` — known-answer search queries against live
+      portals, asserting *which* dataset comes back rather than how many. v0.4.122 shipped
+      with counts verified and ranking broken; "22 results" and "the right dataset first"
+      are different claims, and only the second one is what a user asked for
 - [ ] Security audit clean: `npm audit` (0 vulnerabilities)
 - [ ] All tests passing: `npm test`
 - [ ] Code builds successfully: `npm run build`

--- a/docs/JSON-OUTPUT.md
+++ b/docs/JSON-OUTPUT.md
@@ -39,6 +39,7 @@ Error paths respect the requested format too: with `response_format: "json"` a f
 | Field | Type | Notes |
 |-------|------|-------|
 | `count` | number | Total matching datasets |
+| `effective_query` | string | Present **only when the server rewrote the query** — the caller sent `aria OR acqua` and Solr received `text:(aria OR acqua)`. Absent when the query ran unchanged, which is the common case. The Markdown format has always shown this as **Effective Query**. |
 | `results[].id` | string | Dataset UUID |
 | `results[].name` | string | Machine-readable slug |
 | `results[].title` | string | Human-readable title (falls back to name) |

--- a/openspec/changes/add-effective-query-json/proposal.md
+++ b/openspec/changes/add-effective-query-json/proposal.md
@@ -1,0 +1,30 @@
+# Expose the executed query in JSON search output
+
+## Why
+
+The server rewrites a caller's query before sending it to Solr: a boolean query on a
+portal whose default parser ignores booleans is wrapped as `text:(...)`, with its content
+escaped. The Markdown format has always reported this as **Effective Query**. The JSON
+format does not, so a JSON caller cannot tell whether the query it wrote is the query that
+ran.
+
+That gap cost real time on 2026-09-05. Diagnosing why `bonifica siti contaminati Piemonte`
+returned 5 datasets instead of 22 meant reproducing calls by hand against the portal,
+because the tool's own JSON answer did not say which query it had executed. The release
+gate added in the same change (`npm run smoke`) cannot assert the parser behaviour without
+it either.
+
+## What Changes
+
+- `ckan_package_search` JSON output gains `effective_query`, present **only when the
+  server rewrote the query** and absent when it ran unchanged.
+- No change to the Markdown format, which already carries the same information.
+- No change to any input, and no change to which datasets are returned.
+
+## Impact
+
+- Affected specs: `ckan-search`
+- Affected code: `compactSearchResult()` and its call site in `src/tools/package.ts`
+- Backwards compatible: the field is additive and optional. A client reading `count` and
+  `results` is unaffected.
+- Documented in `docs/JSON-OUTPUT.md`.

--- a/openspec/changes/add-effective-query-json/specs/ckan-search/spec.md
+++ b/openspec/changes/add-effective-query-json/specs/ckan-search/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Executed query visible in JSON output
+
+When the server rewrites a caller's query before sending it to Solr, `ckan_package_search`
+SHALL report the executed query in its JSON output, so that a JSON caller can tell which
+query actually ran. The field SHALL be omitted when the query ran unchanged.
+
+#### Scenario: Query rewritten
+- **WHEN** a JSON caller sends a query the server wraps in `text:(...)`
+- **THEN** the response carries `effective_query` with the query as executed
+
+#### Scenario: Query unchanged
+- **WHEN** a JSON caller sends a query that reaches Solr as written
+- **THEN** the response carries no `effective_query`, and its shape is unchanged

--- a/openspec/changes/add-effective-query-json/tasks.md
+++ b/openspec/changes/add-effective-query-json/tasks.md
@@ -1,0 +1,15 @@
+## 1. Implementation
+
+- [x] 1.1 Add the optional `effectiveQuery` parameter to `compactSearchResult()`
+- [x] 1.2 Pass it from the `ckan_package_search` JSON branch only when it differs from the
+      caller's `q`
+- [x] 1.3 Document the field in `docs/JSON-OUTPUT.md`, stating that it is absent when the
+      query ran unchanged
+
+## 2. Verification
+
+- [x] 2.1 `npm test` green
+- [x] 2.2 Release gate asserts both branches: `wrapped` on a boolean query where the portal
+      needs it, `not_wrapped` on a plain query
+- [x] 2.3 Confirmed against a live portal that a plain query carries no `effective_query`
+      and `aria OR acqua` on dati.comune.milano.it carries `text:(aria OR acqua)`

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "pack:dxt": "rm -rf dxt-staging && mkdir -p dxt-staging/server && npm run build:dxt && echo '{\"type\":\"commonjs\"}' > dxt-staging/server/package.json && mkdir -p dxt-staging/server/node_modules && cp -r node_modules/undici dxt-staging/server/node_modules/ && cp manifest.json icon.png dxt-staging/ && dxt pack dxt-staging ckan-mcp-server.dxt && rm -rf dxt-staging",
     "pack:skill": "mkdir -p tmp && cd skills && zip -r ../tmp/ckan-mcp.skill ckan-mcp/ && cd ..",
     "prepack": "cp README.md .readme-full.md && cp .readme-npm.md README.md",
-    "postpack": "mv .readme-full.md README.md"
+    "postpack": "mv .readme-full.md README.md",
+    "smoke": "node scripts/smoke.mjs"
   },
   "keywords": [
     "mcp",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "pack:skill": "mkdir -p tmp && cd skills && zip -r ../tmp/ckan-mcp.skill ckan-mcp/ && cd ..",
     "prepack": "cp README.md .readme-full.md && cp .readme-npm.md README.md",
     "postpack": "mv .readme-full.md README.md",
-    "smoke": "node scripts/smoke.mjs"
+    "smoke": "npm run build && node scripts/smoke.mjs"
   },
   "keywords": [
     "mcp",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -95,6 +95,29 @@ schema change.
 bash scripts/worker_daily_stats.sh
 ```
 
+## smoke.mjs — the release gate
+
+`npm run smoke` runs the known-answer cases in `tests/smoke/cases.json` against live
+portals and exits non-zero on the first failed assertion. `npm run smoke -- lecce` runs
+only the cases whose name matches.
+
+Every case asserts **which** dataset comes back, not how many, and carries a `regression`
+field naming the failure it guards. That distinction is the reason the file exists:
+v0.4.122 shipped with result counts verified and the ranking broken, because a query
+returning 679 datasets and a query returning the right one first are different claims.
+
+The gate is checked against the defects it claims to catch. Reintroducing the v0.4.121
+wrapping rule fails 4 of the 12 cases; removing the parser probe from
+`ckan_find_relevant_datasets`, the v0.4.122 regression, fails the case that requires the
+two search tools to agree.
+
+Cases hit real portals, so the thresholds are loose enough to survive catalog drift and
+a failure can also mean a portal is down — check the message before assuming a code bug.
+
+```bash
+npm run build && npm run smoke
+```
+
 ## GitHub Actions
 
 `update-telemetry.yml` runs both scripts automatically twice a day (06:00 and 18:00 UTC).

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -55,14 +55,25 @@ async function waitReady(timeoutMs = 20000) {
     }
     try {
       // `tools/list` rather than a health path: the Node HTTP transport exposes only
-      // /mcp, and answering this proves the MCP layer is up, not just the socket.
+      // /mcp. And the answer has to name our tools — a 200 from whatever else happens
+      // to hold the port would otherwise let the whole suite run against it, turning a
+      // bind failure into twelve puzzling case failures.
       const res = await fetch(`http://localhost:${PORT}/mcp`, {
         method: "POST",
         headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
         body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list", id: 0 })
       });
-      if (res.ok) return;
-    } catch { /* not listening yet */ }
+      if (res.ok) {
+        const tools = (await res.json())?.result?.tools ?? [];
+        if (tools.some((t) => t?.name === "ckan_package_search")) return;
+        throw new Error(
+          `something else is answering on port ${PORT}: it replied to tools/list without offering ckan_package_search`
+        );
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message.startsWith("something else")) throw err;
+      /* not listening yet */
+    }
     await sleep(200);
   }
   throw new Error(`server did not answer on port ${PORT} within ${timeoutMs / 1000}s`);

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -27,14 +27,55 @@ const domains = [...new Set(selected.map((c) => new URL(c.server).hostname))].jo
 
 const server = spawn("node", [join(ROOT, "dist/index.js")], {
   env: { ...process.env, TRANSPORT: "http", PORT: String(PORT), CKAN_ALLOWED_DOMAINS: domains },
-  stdio: ["ignore", "ignore", "ignore"]
+  stdio: ["ignore", "ignore", "pipe"]
 });
+
+// A setup problem must look like a setup problem: without this, a missing build or an
+// occupied port surfaces as twelve cases failing with `fetch failed`, which reads like a
+// broken server rather than a runner that never started one.
+let stderr = "";
+server.stderr.on("data", (chunk) => { stderr += chunk.toString(); });
+let exited = null;
+server.on("exit", (code, signal) => { exited = signal ?? `code ${code}`; });
+server.on("error", (err) => { exited = err.message; });
+
 const stop = () => server.kill();
 process.on("exit", stop);
 process.on("SIGINT", () => { stop(); process.exit(130); });
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-await sleep(1500);
+
+/** Wait for the server to answer, rather than guessing how long it takes to boot. */
+async function waitReady(timeoutMs = 20000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (exited !== null) {
+      const tail = stderr.trim().split("\n").slice(-5).join("\n");
+      throw new Error(`server exited before it was ready (${exited})${tail ? `\n${tail}` : ""}`);
+    }
+    try {
+      // `tools/list` rather than a health path: the Node HTTP transport exposes only
+      // /mcp, and answering this proves the MCP layer is up, not just the socket.
+      const res = await fetch(`http://localhost:${PORT}/mcp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+        body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list", id: 0 })
+      });
+      if (res.ok) return;
+    } catch { /* not listening yet */ }
+    await sleep(200);
+  }
+  throw new Error(`server did not answer on port ${PORT} within ${timeoutMs / 1000}s`);
+}
+
+try {
+  await waitReady();
+} catch (err) {
+  console.error(`smoke: ${err.message}`);
+  console.error("hint: `npm run build` produces dist/index.js; SMOKE_PORT moves the port.");
+  stop();
+  process.exit(2);
+}
 
 async function call(tool, server_url, args) {
   const res = await fetch(`http://localhost:${PORT}/mcp`, {
@@ -63,6 +104,17 @@ const firstTitle = (p) => (p.results ?? p.datasets ?? [])[0]?.title ?? "";
 const listLength = (p) =>
   (p.organizations ?? p.tags ?? p.groups ?? p.results ?? p.datasets ?? []).length;
 
+/** Cross-tool invariant: two tools on the same query must see the same catalog. */
+async function compareTools(c) {
+  const mine = totalOf(await call(c.tool, c.server, c.args));
+  const theirs = totalOf(await call(c.compare_with.tool, c.server, c.compare_with.args));
+  if (mine === null || theirs === null) return [`could not read a count from both tools`];
+  const spread = Math.abs(mine - theirs) / Math.max(mine, theirs, 1);
+  return spread <= (c.compare_with.tolerance ?? 0.05)
+    ? []
+    : [`${c.tool} reports ${mine} and ${c.compare_with.tool} reports ${theirs}`];
+}
+
 function check(expect, payload) {
   const fail = [];
   const total = totalOf(payload);
@@ -89,7 +141,9 @@ let failed = 0;
 for (const c of selected) {
   let fails;
   try {
-    fails = check(c.expect, await call(c.tool, c.server, c.args));
+    fails = c.compare_with
+      ? await compareTools(c)
+      : check(c.expect, await call(c.tool, c.server, c.args));
   } catch (err) {
     fails = [`${err.message}`];
   }

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Pre-release gate: known-answer search queries against live portals.
+ *
+ * Every case asserts which dataset must come back, not how many. That distinction is
+ * the reason this file exists: v0.4.122 shipped with counts verified and ranking
+ * broken, because "22 results" and "the right dataset first" are different claims.
+ *
+ *   npm run smoke            all cases
+ *   npm run smoke -- lecce   only cases whose name matches
+ *
+ * Exits non-zero on the first failed assertion, so it can gate a release.
+ */
+
+import { readFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const PORT = Number(process.env.SMOKE_PORT ?? 3099);
+const FILTER = process.argv[2]?.toLowerCase();
+
+const { cases } = JSON.parse(readFileSync(join(ROOT, "tests/smoke/cases.json"), "utf8"));
+const selected = FILTER ? cases.filter((c) => c.name.toLowerCase().includes(FILTER)) : cases;
+const domains = [...new Set(selected.map((c) => new URL(c.server).hostname))].join(",");
+
+const server = spawn("node", [join(ROOT, "dist/index.js")], {
+  env: { ...process.env, TRANSPORT: "http", PORT: String(PORT), CKAN_ALLOWED_DOMAINS: domains },
+  stdio: ["ignore", "ignore", "ignore"]
+});
+const stop = () => server.kill();
+process.on("exit", stop);
+process.on("SIGINT", () => { stop(); process.exit(130); });
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+await sleep(1500);
+
+async function call(tool, server_url, args) {
+  const res = await fetch(`http://localhost:${PORT}/mcp`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "tools/call",
+      params: { name: tool, arguments: { server_url, ...args, response_format: "json" } },
+      id: 1
+    })
+  });
+  const body = await res.json();
+  const text = body?.result?.content?.[0]?.text;
+  if (!text) throw new Error(`no content: ${JSON.stringify(body).slice(0, 200)}`);
+  const payload = JSON.parse(text);
+  if (payload?._error) throw new Error(payload.error ?? "tool returned an error");
+  return payload;
+}
+
+/** The count a tool reports, whichever shape it uses. */
+const totalOf = (p) => p.total_results ?? p.count ?? p.total ?? null;
+/** The title of the first result, whichever list the tool returns. */
+const firstTitle = (p) => (p.results ?? p.datasets ?? [])[0]?.title ?? "";
+/** How many rows a listing tool returned. */
+const listLength = (p) =>
+  (p.organizations ?? p.tags ?? p.groups ?? p.results ?? p.datasets ?? []).length;
+
+function check(expect, payload) {
+  const fail = [];
+  const total = totalOf(payload);
+  const effective = payload.effective_query ?? payload.query ?? "";
+
+  if (expect.total_min !== undefined && !(total >= expect.total_min))
+    fail.push(`expected at least ${expect.total_min} results, got ${total}`);
+  if (expect.total_max !== undefined && !(total <= expect.total_max))
+    fail.push(`expected at most ${expect.total_max} results, got ${total}`);
+  if (expect.count_min !== undefined && !(listLength(payload) >= expect.count_min))
+    fail.push(`expected at least ${expect.count_min} rows, got ${listLength(payload)}`);
+  if (expect.first_matches && !new RegExp(expect.first_matches).test(firstTitle(payload)))
+    fail.push(`first result "${firstTitle(payload).slice(0, 60)}" does not match /${expect.first_matches}/`);
+  if (expect.wrapped && !effective.startsWith("text:("))
+    fail.push(`expected the text:(...) wrapper, effective query was "${effective}"`);
+  if (expect.not_wrapped && effective.startsWith("text:("))
+    fail.push(`expected no wrapper, effective query was "${effective}"`);
+  if (expect.effective_contains && !effective.includes(expect.effective_contains))
+    fail.push(`effective query "${effective}" does not contain "${expect.effective_contains}"`);
+  return fail;
+}
+
+let failed = 0;
+for (const c of selected) {
+  let fails;
+  try {
+    fails = check(c.expect, await call(c.tool, c.server, c.args));
+  } catch (err) {
+    fails = [`${err.message}`];
+  }
+  if (fails.length === 0) {
+    console.log(`  ok    ${c.name}`);
+  } else {
+    failed++;
+    console.log(`  FAIL  ${c.name}`);
+    console.log(`        guards: ${c.regression}`);
+    for (const f of fails) console.log(`        ${f}`);
+  }
+}
+
+console.log(`\n${selected.length - failed}/${selected.length} passed`);
+stop();
+process.exit(failed === 0 ? 0 : 1);

--- a/src/tools/package.ts
+++ b/src/tools/package.ts
@@ -347,13 +347,16 @@ export const scoreDatasetRelevance = (
     breakdown.tags = tagMatch ? weights.tags : 0;
   }
 
-  breakdown.total =
-    breakdown.title +
-    breakdown.notes +
-    breakdown.tags +
-    breakdown.organization +
-    breakdown.holder +
-    breakdown.publisher;
+  // Rounded: the per-field shares are fractions, and summing them raw surfaces
+  // binary-float noise in the output — a score printed as 8.299999999999999.
+  breakdown.total = Math.round(
+    (breakdown.title +
+      breakdown.notes +
+      breakdown.tags +
+      breakdown.organization +
+      breakdown.holder +
+      breakdown.publisher) * 10
+  ) / 10;
 
   return { total: breakdown.total, breakdown, terms };
 };
@@ -621,10 +624,15 @@ function normalizePackage(pkg: CkanPackage): CkanPackage {
 /**
  * Compact JSON representation of package_search results.
  * Keeps only essential fields to reduce token usage (~80% reduction).
+ *
+ * `effective_query` appears only when the server rewrote the caller's query — the
+ * markdown format has always shown it, and a JSON caller had no way to tell which
+ * query actually ran.
  */
-export function compactSearchResult(result: any, serverUrl?: string): object {
+export function compactSearchResult(result: any, serverUrl?: string, effectiveQuery?: string): object {
   return {
     count: result.count,
+    ...(effectiveQuery ? { effective_query: effectiveQuery } : {}),
     results: (result.results || []).map((rawPkg: CkanPackage) => {
       const pkg = serverUrl && requiresMultilingualNormalization(serverUrl) ? normalizePackage(rawPkg) : rawPkg;
       return {
@@ -973,7 +981,11 @@ Typical workflow: ckan_status_show (check locale) → ckan_package_search (query
         }
 
         if (params.response_format === ResponseFormat.JSON) {
-          const compact = compactSearchResult(result, params.server_url);
+          const compact = compactSearchResult(
+            result,
+            params.server_url,
+            effectiveQuery !== params.q ? effectiveQuery : undefined
+          );
           return {
             content: [{ type: "text", text: truncateJson(compact) }]
           };

--- a/tests/smoke/cases.json
+++ b/tests/smoke/cases.json
@@ -6,96 +6,169 @@
       "regression": "v0.4.121: text:(...) wrapping cut this to 5 results",
       "tool": "ckan_package_search",
       "server": "https://www.dati.gov.it/opendata",
-      "args": { "q": "bonifica siti contaminati Piemonte", "rows": 5 },
-      "expect": { "total_min": 15, "not_wrapped": true, "first_matches": "contaminati|bonifica" }
+      "args": {
+        "q": "bonifica siti contaminati Piemonte",
+        "rows": 5
+      },
+      "expect": {
+        "total_min": 15,
+        "not_wrapped": true,
+        "first_matches": "contaminati|bonifica"
+      }
     },
     {
       "name": "long keyword query, the shape an LLM generates",
       "regression": "v0.4.121: returned 0 results while nine datasets existed",
       "tool": "ckan_package_search",
       "server": "https://www.dati.gov.it/opendata",
-      "args": { "q": "musei roma arte opere catalogo", "rows": 3 },
-      "expect": { "total_min": 5, "not_wrapped": true, "first_matches": "[Oo]pere|[Mm]usei" }
+      "args": {
+        "q": "musei roma arte opere catalogo",
+        "rows": 3
+      },
+      "expect": {
+        "total_min": 5,
+        "not_wrapped": true,
+        "first_matches": "[Oo]pere|[Mm]usei"
+      }
     },
     {
       "name": "boolean query is wrapped where the portal ignores OR",
       "regression": "v0.4.122: find_relevant_datasets returned 0 against 87 here",
       "tool": "ckan_package_search",
       "server": "https://dati.comune.milano.it",
-      "args": { "q": "aria OR acqua", "rows": 3 },
-      "expect": { "total_min": 50, "wrapped": true }
+      "args": {
+        "q": "aria OR acqua",
+        "rows": 3
+      },
+      "expect": {
+        "total_min": 50,
+        "wrapped": true
+      }
     },
     {
       "name": "both search tools agree on a boolean query",
       "regression": "v0.4.122: find_relevant_datasets never called the parser probe",
-      "tool": "ckan_find_relevant_datasets",
+      "tool": "ckan_package_search",
       "server": "https://dati.comune.milano.it",
-      "args": { "query": "aria OR acqua", "limit": 3 },
-      "expect": { "total_min": 50 }
+      "args": {
+        "q": "aria OR acqua",
+        "rows": 1
+      },
+      "compare_with": {
+        "tool": "ckan_find_relevant_datasets",
+        "args": {
+          "query": "aria OR acqua",
+          "limit": 1
+        }
+      }
     },
     {
       "name": "unary operator survives, exclusion not inverted",
       "regression": "v0.4.121: escaping turned -rifiuti into a requirement, 7649 -> 398",
       "tool": "ckan_package_search",
       "server": "https://www.dati.gov.it/opendata",
-      "args": { "q": "ambiente -rifiuti", "rows": 2 },
-      "expect": { "total_min": 3000, "not_wrapped": true }
+      "args": {
+        "q": "ambiente -rifiuti",
+        "rows": 2
+      },
+      "expect": {
+        "total_min": 3000,
+        "not_wrapped": true
+      }
     },
     {
       "name": "punctuation inside a word is wrapped, dismax reads it as NOT",
       "regression": "unwrapped e-government matches 58919 of ~65000 datasets",
       "tool": "ckan_package_search",
       "server": "https://www.dati.gov.it/opendata",
-      "args": { "q": "e-government", "rows": 2 },
-      "expect": { "total_max": 5000, "wrapped": true }
+      "args": {
+        "q": "e-government",
+        "rows": 2
+      },
+      "expect": {
+        "total_max": 5000,
+        "wrapped": true
+      }
     },
     {
       "name": "grouping parentheses survive the escaping",
       "regression": "escaped parentheses became literal tokens",
       "tool": "ckan_package_search",
       "server": "https://www.dati.gov.it/opendata",
-      "args": { "q": "(aria OR acqua) AND Milano", "rows": 2 },
-      "expect": { "total_min": 20, "effective_contains": "text:((aria OR acqua) AND Milano)" }
+      "args": {
+        "q": "(aria OR acqua) AND Milano",
+        "rows": 2
+      },
+      "expect": {
+        "total_min": 20,
+        "effective_contains": "text:((aria OR acqua) AND Milano)"
+      }
     },
     {
       "name": "portal whose text field is empty is never wrapped",
       "regression": "wrapping Zurich returns 0 for every query",
       "tool": "ckan_package_search",
       "server": "https://data.stadt-zuerich.ch",
-      "args": { "q": "Bevölkerung OR Einwohner", "rows": 2 },
-      "expect": { "total_min": 5, "not_wrapped": true }
+      "args": {
+        "q": "Bevölkerung OR Einwohner",
+        "rows": 2
+      },
+      "expect": {
+        "total_min": 5,
+        "not_wrapped": true
+      }
     },
     {
       "name": "the right dataset ranks first, not just any dataset",
       "regression": "v0.4.122: Trento, Martina Franca and Desio outranked the Lecce dataset",
       "tool": "ckan_find_relevant_datasets",
       "server": "https://www.dati.gov.it/opendata",
-      "args": { "query": "defibrillatori Comune di Lecce", "limit": 3 },
-      "expect": { "total_min": 100, "first_matches": "Cardioprotetto" }
+      "args": {
+        "query": "defibrillatori Comune di Lecce",
+        "limit": 3
+      },
+      "expect": {
+        "total_min": 100,
+        "first_matches": "Cardioprotetto"
+      }
     },
     {
       "name": "accented terms contribute to the ranking",
       "regression": "\\b is ASCII in JS, so qualità scored zero",
       "tool": "ckan_find_relevant_datasets",
       "server": "https://www.dati.gov.it/opendata",
-      "args": { "query": "qualità dell'aria Milano", "limit": 3 },
-      "expect": { "first_matches": "[Aa]ria|[Qq]ualità" }
+      "args": {
+        "query": "qualità dell'aria Milano",
+        "limit": 3
+      },
+      "expect": {
+        "first_matches": "[Aa]ria|[Qq]ualità"
+      }
     },
     {
       "name": "organization filter folds accents before the Solr wildcard",
       "regression": "città returned 0 while citta matched 135 datasets",
       "tool": "ckan_organization_search",
       "server": "https://www.dati.gov.it/opendata",
-      "args": { "pattern": "città" },
-      "expect": { "count_min": 1 }
+      "args": {
+        "pattern": "città"
+      },
+      "expect": {
+        "count_min": 1
+      }
     },
     {
       "name": "tag filter searches beyond the most frequent tags",
       "regression": "53 tags contain citta, none in the top 100, filter said none existed",
       "tool": "ckan_tag_list",
       "server": "https://www.dati.gov.it/opendata",
-      "args": { "tag_query": "città", "limit": 3 },
-      "expect": { "count_min": 1 }
+      "args": {
+        "tag_query": "città",
+        "limit": 3
+      },
+      "expect": {
+        "count_min": 1
+      }
     }
   ]
 }

--- a/tests/smoke/cases.json
+++ b/tests/smoke/cases.json
@@ -1,0 +1,101 @@
+{
+  "_comment": "Known-answer cases for the pre-release gate. Every case asserts which dataset must come back, not how many. Thresholds are deliberately loose so catalog drift does not cause false alarms; they are tight enough to catch the failures this file was written for, listed in `regression`.",
+  "cases": [
+    {
+      "name": "plain multi-term query reaches the portal parser",
+      "regression": "v0.4.121: text:(...) wrapping cut this to 5 results",
+      "tool": "ckan_package_search",
+      "server": "https://www.dati.gov.it/opendata",
+      "args": { "q": "bonifica siti contaminati Piemonte", "rows": 5 },
+      "expect": { "total_min": 15, "not_wrapped": true, "first_matches": "contaminati|bonifica" }
+    },
+    {
+      "name": "long keyword query, the shape an LLM generates",
+      "regression": "v0.4.121: returned 0 results while nine datasets existed",
+      "tool": "ckan_package_search",
+      "server": "https://www.dati.gov.it/opendata",
+      "args": { "q": "musei roma arte opere catalogo", "rows": 3 },
+      "expect": { "total_min": 5, "not_wrapped": true, "first_matches": "[Oo]pere|[Mm]usei" }
+    },
+    {
+      "name": "boolean query is wrapped where the portal ignores OR",
+      "regression": "v0.4.122: find_relevant_datasets returned 0 against 87 here",
+      "tool": "ckan_package_search",
+      "server": "https://dati.comune.milano.it",
+      "args": { "q": "aria OR acqua", "rows": 3 },
+      "expect": { "total_min": 50, "wrapped": true }
+    },
+    {
+      "name": "both search tools agree on a boolean query",
+      "regression": "v0.4.122: find_relevant_datasets never called the parser probe",
+      "tool": "ckan_find_relevant_datasets",
+      "server": "https://dati.comune.milano.it",
+      "args": { "query": "aria OR acqua", "limit": 3 },
+      "expect": { "total_min": 50 }
+    },
+    {
+      "name": "unary operator survives, exclusion not inverted",
+      "regression": "v0.4.121: escaping turned -rifiuti into a requirement, 7649 -> 398",
+      "tool": "ckan_package_search",
+      "server": "https://www.dati.gov.it/opendata",
+      "args": { "q": "ambiente -rifiuti", "rows": 2 },
+      "expect": { "total_min": 3000, "not_wrapped": true }
+    },
+    {
+      "name": "punctuation inside a word is wrapped, dismax reads it as NOT",
+      "regression": "unwrapped e-government matches 58919 of ~65000 datasets",
+      "tool": "ckan_package_search",
+      "server": "https://www.dati.gov.it/opendata",
+      "args": { "q": "e-government", "rows": 2 },
+      "expect": { "total_max": 5000, "wrapped": true }
+    },
+    {
+      "name": "grouping parentheses survive the escaping",
+      "regression": "escaped parentheses became literal tokens",
+      "tool": "ckan_package_search",
+      "server": "https://www.dati.gov.it/opendata",
+      "args": { "q": "(aria OR acqua) AND Milano", "rows": 2 },
+      "expect": { "total_min": 20, "effective_contains": "text:((aria OR acqua) AND Milano)" }
+    },
+    {
+      "name": "portal whose text field is empty is never wrapped",
+      "regression": "wrapping Zurich returns 0 for every query",
+      "tool": "ckan_package_search",
+      "server": "https://data.stadt-zuerich.ch",
+      "args": { "q": "Bevölkerung OR Einwohner", "rows": 2 },
+      "expect": { "total_min": 5, "not_wrapped": true }
+    },
+    {
+      "name": "the right dataset ranks first, not just any dataset",
+      "regression": "v0.4.122: Trento, Martina Franca and Desio outranked the Lecce dataset",
+      "tool": "ckan_find_relevant_datasets",
+      "server": "https://www.dati.gov.it/opendata",
+      "args": { "query": "defibrillatori Comune di Lecce", "limit": 3 },
+      "expect": { "total_min": 100, "first_matches": "Cardioprotetto" }
+    },
+    {
+      "name": "accented terms contribute to the ranking",
+      "regression": "\\b is ASCII in JS, so qualità scored zero",
+      "tool": "ckan_find_relevant_datasets",
+      "server": "https://www.dati.gov.it/opendata",
+      "args": { "query": "qualità dell'aria Milano", "limit": 3 },
+      "expect": { "first_matches": "[Aa]ria|[Qq]ualità" }
+    },
+    {
+      "name": "organization filter folds accents before the Solr wildcard",
+      "regression": "città returned 0 while citta matched 135 datasets",
+      "tool": "ckan_organization_search",
+      "server": "https://www.dati.gov.it/opendata",
+      "args": { "pattern": "città" },
+      "expect": { "count_min": 1 }
+    },
+    {
+      "name": "tag filter searches beyond the most frequent tags",
+      "regression": "53 tags contain citta, none in the top 100, filter said none existed",
+      "tool": "ckan_tag_list",
+      "server": "https://www.dati.gov.it/opendata",
+      "args": { "tag_query": "città", "limit": 3 },
+      "expect": { "count_min": 1 }
+    }
+  ]
+}

--- a/tests/unit/package-scoring.test.ts
+++ b/tests/unit/package-scoring.test.ts
@@ -643,3 +643,17 @@ describe('multilingual term extraction', () => {
     expect(extractQueryTerms('mobilita\u0300')).toEqual(['mobilità'.normalize('NFC')]);
   });
 });
+
+describe('score total', () => {
+  it('does not leak binary-float noise into the output', () => {
+    // A real result printed as 8.299999999999999 before rounding the sum.
+    const dataset = {
+      title: 'Sinistri stradali rilevati nel territorio comunale',
+      notes: 'incidenti a Palermo',
+      tags: [{ name: 'incidenti' }],
+      organization: { title: 'Comune di Palermo' }
+    } as any;
+    const { total } = scoreDatasetRelevance('incidenti stradali Palermo', dataset);
+    expect(total).toBe(Math.round(total * 10) / 10);
+  });
+});


### PR DESCRIPTION
## Why

Three releases went out today, two of them to repair the one before. The verification in between was a sequence of commands rebuilt from memory each time, so it covered something different on each pass — and every pass covered result counts.

That is how v0.4.122 shipped with counts verified and the ranking broken. `bonifica siti contaminati Piemonte` went from 5 results to 22, which was the fix working; `defibrillatori Comune di Lecce` went from 1 result to 679 with the Lecce dataset nowhere in the top three, which was a regression. Both look identical if you only check how many results came back.

For a repository with downstream reuse this cannot depend on what I remember to try.

## What this adds

`npm run smoke` — twelve known-answer cases in `tests/smoke/cases.json`, drawn from real telemetry. Each asserts **which** dataset must come back, carries a `regression` field naming the failure it guards, and covers every tool that shares the query-building path plus the tag and organization filters, across four portals.

The runner starts the built server over HTTP and calls each tool the way a client does, so it exercises schemas and descriptions rather than a function in isolation. It exits non-zero on the first failure. `npm run smoke -- lecce` runs a subset.

Wired into `CLAUDE.md` as step 2 of the release workflow, before the tag, and into the `docs/DEPLOYMENT.md` pre-release checklist.

## The gate is checked against the defects it claims to catch

Reintroducing the v0.4.121 wrapping rule:

```
FAIL  plain multi-term query reaches the portal parser
FAIL  long keyword query, the shape an LLM generates
FAIL  unary operator survives, exclusion not inverted
FAIL  the right dataset ranks first, not just any dataset
8/12 passed
```

Removing the parser probe from `ckan_find_relevant_datasets`, which is the v0.4.122 regression:

```
FAIL  both search tools agree on a boolean query
      expected at least 50 results, got 0
```

Clean tree: 12/12.

## Two things the gate needed

**`effective_query` in JSON output.** The Markdown format has always shown which query actually reached Solr; the JSON format did not, so a JSON caller could not tell whether the server had rewritten the query — and neither could the gate. It now appears in `ckan_package_search` JSON when the query was rewritten, and is absent when it ran unchanged. Documented in `docs/JSON-OUTPUT.md`.

**Rounded score totals.** Relevance scores summed unrounded fractions, printing totals like `8.299999999999999`.

## Known, not fixed

The ranking model weights every query term equally, so on `defibrillatori Comune di Lecce` three datasets tie at 9.7 and the right one leads on Solr order rather than on score. Making the `tags` field proportional like the other fields was tried and reverted: it promotes "Elenco patrocini Comune di Lecce", whose tags carry two of the three terms, over the dataset that actually answers the question. The fix is term specificity — rarer terms weighing more — which is a design change and deserves its own issue rather than a patch at the end of a release.

536 tests, 1 added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
