### PR TITLE
fix(portals): say that catalog.data.gov left CKAN instead of "Unknown error"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,7 +323,6 @@ TypeScript configuration (for IDE):
 The server can connect to any CKAN instance. Some main portals:
 
 - 🇮🇹 https://dati.gov.it (Italy)
-- 🇺🇸 https://catalog.data.gov (United States)
 - 🇨🇦 https://open.canada.ca/data (Canada)
 - 🇬🇧 https://data.gov.uk (United Kingdom)
 - 🌍 https://demo.ckan.org (Official CKAN Demo)

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -169,25 +169,9 @@ Returns quality score and detailed metrics from data.europa.eu MQA (Metadata Qua
 
 **Note**: Only works with dati.gov.it datasets. Uses the `identifier` field (or falls back to `name`) to query the European MQA API.
 
-## USA Examples - data.gov
+## USA - data.gov
 
-### Search government datasets
-```typescript
-ckan_package_search({
-  server_url: "https://catalog.data.gov",
-  q: "climate change",
-  rows: 20
-})
-```
-
-### Datasets by tag
-```typescript
-ckan_package_search({
-  server_url: "https://catalog.data.gov",
-  q: "tags:health",
-  rows: 20
-})
-```
+`catalog.data.gov` stopped being a CKAN portal in 2025: Data.gov now serves its catalog through a different API (`api.gsa.gov/technology/datagov/v4`, key required, not CKAN-compatible). A call to it returns an error that says so. See [#540](https://github.com/ondata/ckan-mcp-server/issues/540).
 
 ## CKAN Demo Examples
 

--- a/LOG.md
+++ b/LOG.md
@@ -1,5 +1,34 @@
 # LOG
 
+## 2026-09-06
+
+### catalog.data.gov has not been CKAN since 2025; we said otherwise in twelve places
+
+Checking the two configured portals that answered nothing yesterday. `dati.arpae.it` is
+still CKAN and still at the same address, just down most of the time — site-wide 500s,
+not ours to fix (#541). `catalog.data.gov` is a different story: Data.gov replaced its
+CKAN catalog with a Flask/OpenSearch application in 2025 and the CKAN-compatible
+endpoints — `catalog-old.data.gov`, the `api.gsa.gov/…/v3` gateway — now all redirect to
+the new host, which answers 404 to any CKAN request. The replacement API (`…/v4/search`)
+needs a key, paginates with a cursor and, per GSA, will not support CKAN filter syntax.
+47 calls reached it through the public deployment since April and got
+`CKAN API error (404): Unknown error`, while README, EXAMPLES, CLAUDE.md, the skill and a
+tool description all listed it as a working CKAN portal (#540).
+
+Fixed the part that is ours: `portals.json` entries can carry a `migrated` block, the
+`catalog-data-gov` entry is kept and marked so the hint keeps firing, `CkanApiError` now
+carries the portal URL, and `formatCkanError` returns the migration notice for such a
+portal whatever the status — no status-based hint can be right for it. `ckan_status_show`
+routes its error through the formatter too. Every document that presented it as CKAN now
+says the opposite; the skill's country table says "NOT CKAN since 2025", which is what
+stops an LLM client from trying. A v4 adapter is a separate proposal.
+
+The gate gained a case that calls the live portal and expects the notice; 13/13.
+OpenSpec change `mark-migrated-portals` on `ckan-error-hints`. 542 tests, 6 added.
+
+Left alone: `docs/DECISIONS.md` still describes the parser probe replaced in #534 and says
+configured portals skip it. Stale independently of this change; flagged, not touched.
+
 ## 2026-09-05
 
 ### A release gate that asserts which dataset comes back

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -23,7 +23,7 @@ All data accessed through this server is **publicly available** on the respectiv
 
 ## Third-Party Services
 
-Queries are sent to the CKAN portal you configure (e.g., `https://dati.gov.it`, `https://catalog.data.gov`). Those portals have their own privacy policies and terms of use.
+Queries are sent to the CKAN portal you configure (e.g., `https://dati.gov.it`, `https://open.canada.ca/data`). Those portals have their own privacy policies and terms of use.
 
 ## Open Source
 

--- a/README.md
+++ b/README.md
@@ -534,11 +534,12 @@ npx skills add ondata/ckan-mcp-server --skill ckan-mcp
 Some examples of supported portals:
 
 - 🇮🇹 **https://www.dati.gov.it/opendata** - Italian National Open Data Portal (CKAN 2.10.3)
-- 🇺🇸 **https://catalog.data.gov** - United States Open Data (CKAN 2.11.4)
 - 🇨🇦 **https://open.canada.ca/data** - Canada Open Government (CKAN 2.10.8)
 - 🇦🇺 **https://data.gov.au** - Australian Government Open Data (CKAN 2.11.4)
 - 🇬🇧 **https://data.gov.uk** - United Kingdom Open Data
 - And many more portals worldwide
+
+> **catalog.data.gov is no longer CKAN.** Data.gov replaced its catalog in 2025 with a different API ([details](https://github.com/ondata/ckan-mcp-server/issues/540)); a call to it now explains this instead of failing with a bare 404.
 
 ### Discover CKAN portals worldwide
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -473,7 +473,6 @@ The server can connect to **any public CKAN server**. Main portals:
 | Country | Portal | URL |
 |---------|--------|-----|
 | 🇮🇹 Italia | Portale Nazionale Dati Aperti | https://www.dati.gov.it/opendata |
-| 🇺🇸 USA | Data.gov | https://catalog.data.gov |
 | 🇨🇦 Canada | Open Government | https://open.canada.ca/data |
 | 🇬🇧 UK | Data.gov.uk | https://data.gov.uk |
 | 🇪🇺 EU | European Data Portal | https://data.europa.eu |

--- a/openspec/changes/mark-migrated-portals/proposal.md
+++ b/openspec/changes/mark-migrated-portals/proposal.md
@@ -1,0 +1,35 @@
+# Tell the caller when a portal has left CKAN
+
+## Why
+
+`catalog.data.gov` stopped being a CKAN portal in 2025. Every CKAN request to it now
+returns a bare 404, and this server reported that as `CKAN API error (404): Unknown error`
+— false in the way that matters, since the server is up and the data exists, just behind
+a different API. 47 calls reached it through the public deployment between April and
+September 2026, each answered with nothing useful, while our own README, examples and tool
+descriptions kept presenting it as a working CKAN portal.
+
+The status-based hints in `formatCkanError` cannot help here: a migrated portal answers
+every action alike, so no hint keyed on status or action can be right for it.
+
+## What Changes
+
+- `portals.json` entries gain an optional `migrated` block (`notice`, `docs_url`). The
+  entry for `catalog.data.gov` is kept and marked, rather than deleted, so the hint keeps
+  firing for the callers who still try it.
+- `CkanApiError` carries the portal URL the request went to, so the formatter knows the
+  error's origin. Additive: `status` and `action` are unchanged.
+- `formatCkanError` returns the migration notice for a migrated portal, whatever the
+  status, ahead of the status-based hints.
+- `ckan_status_show` routes its error through `formatCkanError`, so the notice appears
+  there too instead of "offline or not a valid CKAN instance".
+- Every document that listed `catalog.data.gov` as a CKAN example says the opposite.
+
+## Impact
+
+- Affected specs: `ckan-error-hints`
+- Affected code: `src/utils/portal-config.ts`, `src/utils/http.ts`, `src/tools/status.ts`,
+  `src/portals.json`, `src/tools/organization.ts` (description only)
+- Backwards compatible: no input changes; error text for migrated portals becomes
+  informative, error text for every other portal is unchanged.
+- A v4 adapter for data.gov is out of scope and would be its own proposal (#540).

--- a/openspec/changes/mark-migrated-portals/specs/ckan-error-hints/spec.md
+++ b/openspec/changes/mark-migrated-portals/specs/ckan-error-hints/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Migrated portal notice
+
+`CkanApiError` SHALL carry the portal URL the failed request went to, and `formatCkanError`
+SHALL return that portal's migration notice, whatever the HTTP status, when `portals.json`
+marks the portal as migrated. A migrated portal answers every CKAN action alike, so the
+notice MUST take precedence over the status-based hints.
+
+#### Scenario: Call to a migrated portal
+- **WHEN** a request to a portal marked `migrated` fails with any status
+- **THEN** the formatted error carries the portal's notice and its `docs_url`
+- **AND** no status-based hint is appended
+
+#### Scenario: Call to any other portal
+- **WHEN** a request to a portal not marked `migrated` fails
+- **THEN** the formatted error is unchanged from before this requirement
+
+#### Scenario: Status tool
+- **WHEN** `ckan_status_show` is called on a migrated portal
+- **THEN** its error carries the same notice

--- a/openspec/changes/mark-migrated-portals/tasks.md
+++ b/openspec/changes/mark-migrated-portals/tasks.md
@@ -1,0 +1,17 @@
+## 1. Implementation
+
+- [x] 1.1 `migrated` block on the `catalog-data-gov` entry, `getPortalMigration()` in
+      `portal-config.ts`
+- [x] 1.2 `CkanApiError.serverUrl`, set at every construction site in `makeCkanRequest`
+- [x] 1.3 `formatCkanError` short-circuits to the migration notice
+- [x] 1.4 `ckan_status_show` uses `formatCkanError`
+- [x] 1.5 README, EXAMPLES, CLAUDE.md, src/README, SKILL.md, PRD, PRIVACY, project.md and
+      the `ckan_organization_search` description no longer present it as CKAN
+
+## 2. Verification
+
+- [x] 2.1 Unit tests: migrated portal gets the notice on 404 and on 500; a non-migrated
+      portal keeps the status hint; `getPortalMigration` on alias and unknown host
+- [x] 2.2 Smoke case against the live portal: the answer carries the notice
+- [x] 2.3 `grep catalog.data.gov` outside LOG/archive finds only the migration note and
+      the portals entry

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -94,7 +94,6 @@ Exposes MCP tools for:
 ### CKAN Portals
 Major supported portals:
 - 🇮🇹 https://dati.gov.it/opendata (Italia)
-- 🇺🇸 https://catalog.data.gov (United States)
 - 🇨🇦 https://open.canada.ca/data (Canada)
 - 🇬🇧 https://data.gov.uk (United Kingdom)
 - 🇪🇺 https://data.europa.eu (European Union)

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -155,8 +155,12 @@ for (const c of selected) {
     fails = c.compare_with
       ? await compareTools(c)
       : check(c.expect, await call(c.tool, c.server, c.args));
+    if (c.expect?.error_matches) fails = [`expected an error matching /${c.expect.error_matches}/, got a result`];
   } catch (err) {
-    fails = [`${err.message}`];
+    // Some cases exist to pin down what the error says, not that a result comes back.
+    fails = c.expect?.error_matches && new RegExp(c.expect.error_matches).test(err.message)
+      ? []
+      : [`${err.message}`];
   }
   if (fails.length === 0) {
     console.log(`  ok    ${c.name}`);

--- a/skills/ckan-mcp/SKILL.md
+++ b/skills/ckan-mcp/SKILL.md
@@ -386,7 +386,7 @@ fq: "res_format:CSV OR res_format:JSON"
 |--------------|--------|------|
 | Italy | dati.gov.it | Primary |
 | France | data.europa.eu | data.gouv.fr is NOT CKAN |
-| USA | catalog.data.gov | |
+| USA | — | catalog.data.gov is NOT CKAN since 2025 (new API at api.gsa.gov v4, not supported) |
 | Canada | open.canada.ca/data | |
 | UK | data.gov.uk | |
 | EU / multi-country | data.europa.eu | Default for cross-border |

--- a/src/README.md
+++ b/src/README.md
@@ -192,7 +192,7 @@ The following portals have been tested and verified (as of v0.4.37):
 |--------|---------|--------------|-------|
 | dati.gov.it/opendata | 🇮🇹 Italy | 2.10.3 | Custom `dataset_view_url` and `organization_view_url` |
 | dati.anticorruzione.it/opendata | 🇮🇹 Italy | — | Standard configuration |
-| catalog.data.gov | 🇺🇸 USA | 2.11.4 | Standard configuration |
+| catalog.data.gov | 🇺🇸 USA | — | **Migrated off CKAN in 2025.** Entry kept, marked `migrated`, so a call to it explains where the data went (#540) |
 | open.canada.ca/data | 🇨🇦 Canada | 2.10.8 | Standard configuration |
 | data.gov.au | 🇦🇺 Australia | 2.11.4 | Custom `dataset_view_url` and `organization_view_url` |
 | ckan.opendata.swiss | 🇨🇭 Switzerland | — | Standard configuration |

--- a/src/portals.json
+++ b/src/portals.json
@@ -58,7 +58,11 @@
       "api_url": "https://catalog.data.gov",
       "api_url_aliases": [
         "http://catalog.data.gov"
-      ]
+      ],
+      "migrated": {
+        "notice": "catalog.data.gov stopped being a CKAN portal in 2025. Data.gov now serves its catalog through a different API (api.gsa.gov/technology/datagov/v4, key required, not CKAN-compatible), which this server does not speak.",
+        "docs_url": "https://resources.data.gov/catalog-api/"
+      }
     },
     {
       "id": "open-canada",
@@ -79,8 +83,7 @@
         "https://www.data.gov.au",
         "http://www.data.gov.au"
       ],
-      "dataset_view_url": "https://data.gov.au/data/dataset/{name}"
-      ,
+      "dataset_view_url": "https://data.gov.au/data/dataset/{name}",
       "organization_view_url": "https://data.gov.au/data/organization/{name}"
     },
     {

--- a/src/tools/organization.ts
+++ b/src/tools/organization.ts
@@ -358,7 +358,7 @@ Returns:
 
 Examples:
   - { server_url: "https://www.dati.gov.it/opendata", pattern: "toscana" }
-  - { server_url: "https://catalog.data.gov", pattern: "health" }
+  - { server_url: "https://open.canada.ca/data", pattern: "health" }
 
 Typical workflow: ckan_organization_search → ckan_organization_show (get details) → ckan_package_search with fq="organization:name"`,
       inputSchema: z.object({

--- a/src/tools/status.ts
+++ b/src/tools/status.ts
@@ -3,9 +3,9 @@
  */
 
 import { z } from "zod";
-import { makeCkanRequest, formatCkanError } from "../utils/http.js";
+import { makeCkanRequest, formatCkanError, CkanApiError } from "../utils/http.js";
 import { truncateText, cappedStructured, addDemoFooter } from "../utils/formatting.js";
-import { getPortalSparqlConfig, getPortalHvdConfig } from "../utils/portal-config.js";
+import { getPortalSparqlConfig, getPortalHvdConfig, getPortalMigration } from "../utils/portal-config.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 export function formatStatusMarkdown(result: { ckan_version?: string; site_title?: string; site_url?: string; locale_default?: string }, serverUrl: string, hvdCount?: number): string {
@@ -77,12 +77,15 @@ Typical workflow: ckan_status_show (verify server is up) → ckan_package_search
           structuredContent: cappedStructured(result)
         };
       } catch (error) {
+        // A portal that left CKAN is neither offline nor invalid: the migration notice
+        // is the whole diagnosis, and the usual prefix would contradict it.
+        const migrated =
+          error instanceof CkanApiError && error.serverUrl && getPortalMigration(error.serverUrl);
+        const detail = formatCkanError(error, "ckan_status_show");
         return {
           content: [{
             type: "text",
-            // formatCkanError, not error.message: a portal that left CKAN is neither
-            // offline nor invalid, and the hint is the only useful thing to say.
-            text: `Server appears to be offline or not a valid CKAN instance:\n${formatCkanError(error, "ckan_status_show")}`
+            text: migrated ? detail : `Server appears to be offline or not a valid CKAN instance:\n${detail}`
           }],
           isError: true
         };

--- a/src/tools/status.ts
+++ b/src/tools/status.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from "zod";
-import { makeCkanRequest } from "../utils/http.js";
+import { makeCkanRequest, formatCkanError } from "../utils/http.js";
 import { truncateText, cappedStructured, addDemoFooter } from "../utils/formatting.js";
 import { getPortalSparqlConfig, getPortalHvdConfig } from "../utils/portal-config.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -80,7 +80,9 @@ Typical workflow: ckan_status_show (verify server is up) → ckan_package_search
         return {
           content: [{
             type: "text",
-            text: `Server appears to be offline or not a valid CKAN instance:\n${error instanceof Error ? error.message : String(error)}`
+            // formatCkanError, not error.message: a portal that left CKAN is neither
+            // offline nor invalid, and the hint is the only useful thing to say.
+            text: `Server appears to be offline or not a valid CKAN instance:\n${formatCkanError(error, "ckan_status_show")}`
           }],
           isError: true
         };

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -3,7 +3,7 @@
  */
 
 import axios, { AxiosError } from "axios";
-import { getPortalApiUrlForHostname, getPortalApiPath } from "./portal-config.js";
+import { getPortalApiUrlForHostname, getPortalApiPath, getPortalMigration } from "./portal-config.js";
 import {
   buildCacheKey,
   getCache,
@@ -23,11 +23,14 @@ export interface MakeCkanRequestOptions {
 export class CkanApiError extends Error {
   readonly status: number | undefined;
   readonly action: string;
-  constructor(message: string, status: number | undefined, action: string) {
+  /** The portal the request went to, as the caller wrote it: lets the hint know its origin. */
+  readonly serverUrl: string | undefined;
+  constructor(message: string, status: number | undefined, action: string, serverUrl?: string) {
     super(message);
     this.name = 'CkanApiError';
     this.status = status;
     this.action = action;
+    this.serverUrl = serverUrl;
   }
 }
 
@@ -35,7 +38,16 @@ export function formatCkanError(error: unknown, _toolName: string): string {
   if (!(error instanceof CkanApiError)) {
     return error instanceof Error ? error.message : String(error);
   }
-  const { status, action, message } = error;
+  const { status, action, message, serverUrl } = error;
+
+  // A portal that left CKAN answers every CKAN request the same way — catalog.data.gov
+  // returns a bare 404 — so no status-based hint can be right for it. Say what happened
+  // and where the data went, whatever the status.
+  const migration = serverUrl ? getPortalMigration(serverUrl) : null;
+  if (migration) {
+    return `${message}\n→ ${migration.notice} See ${migration.docs_url}`;
+  }
+
   let hint = '';
   if (status === 404) {
     if (action === 'datastore_search_sql') {
@@ -776,16 +788,16 @@ export async function makeCkanRequest<T>(
       }
 
       if (!response.ok) {
-        throw new CkanApiError(`CKAN API error (${response.status}): ${response.statusText}`, response.status, action);
+        throw new CkanApiError(`CKAN API error (${response.status}): ${response.statusText}`, response.status, action, serverUrl);
       }
 
       const declaredLength = Number(response.headers.get("content-length"));
       if (Number.isFinite(declaredLength) && declaredLength > MAX_RESPONSE_BYTES) {
-        throw new CkanApiError(`Response too large (${declaredLength} bytes)`, undefined, action);
+        throw new CkanApiError(`Response too large (${declaredLength} bytes)`, undefined, action, serverUrl);
       }
       const buffer = await response.arrayBuffer();
       if (buffer.byteLength > MAX_RESPONSE_BYTES) {
-        throw new CkanApiError(`Response too large (${buffer.byteLength} bytes)`, undefined, action);
+        throw new CkanApiError(`Response too large (${buffer.byteLength} bytes)`, undefined, action, serverUrl);
       }
       const headers: Record<string, string> = {};
       response.headers.forEach((headerValue, headerKey) => {
@@ -823,7 +835,8 @@ export async function makeCkanRequest<T>(
       throw new CkanApiError(
         `CKAN API returned success=false for action "${action}".`,
         undefined,
-        action
+        action,
+        serverUrl
       );
     }
   } catch (error) {
@@ -834,7 +847,7 @@ export async function makeCkanRequest<T>(
         const status = axiosError.response.status;
         const data = axiosError.response.data as any;
         const errorMsg = data?.error?.message || data?.error || 'Unknown error';
-        throw new CkanApiError(`CKAN API error (${status}): ${errorMsg}`, status, action);
+        throw new CkanApiError(`CKAN API error (${status}): ${errorMsg}`, status, action, serverUrl);
       } else if (axiosError.code === 'ECONNABORTED') {
         throw new Error(`Request timeout connecting to ${serverUrl}`);
       } else if (axiosError.code === 'ENOTFOUND') {

--- a/src/utils/portal-config.ts
+++ b/src/utils/portal-config.ts
@@ -62,8 +62,18 @@ export function getPortalConfig(serverUrl: string): PortalConfig | null {
   return portal || null;
 }
 
+/**
+ * Looked up by hostname, not by exact URL: a host that left CKAN has left it for
+ * every path, port and spelling, and the request router already resolves configured
+ * portals by hostname — `https://CATALOG.DATA.GOV:443/` must get the same answer.
+ */
 export function getPortalMigration(serverUrl: string): PortalMigration | null {
-  return getPortalConfig(serverUrl)?.migrated ?? null;
+  const hostname = extractHostname(serverUrl);
+  if (!hostname) return null;
+  const portal = (portalsConfig.portals as PortalConfig[]).find((p) =>
+    [p.api_url, ...(p.api_url_aliases || [])].some((url) => extractHostname(url) === hostname)
+  );
+  return portal?.migrated ?? null;
 }
 
 export function getPortalSearchConfig(serverUrl: string): PortalSearchConfig {

--- a/src/utils/portal-config.ts
+++ b/src/utils/portal-config.ts
@@ -13,6 +13,16 @@ export type SparqlConfig = {
   method?: "GET" | "POST";
 };
 
+/**
+ * A portal that used to be CKAN and no longer is. The entry stays in portals.json so
+ * that a call to it can say what happened and where the data went, instead of the
+ * bare 404 the new platform returns to a CKAN request.
+ */
+export type PortalMigration = {
+  notice: string;
+  docs_url: string;
+};
+
 type PortalConfig = {
   api_url: string;
   api_url_aliases?: string[];
@@ -21,6 +31,7 @@ type PortalConfig = {
   hvd?: HvdConfig;
   sparql?: SparqlConfig;
   normalize?: string;
+  migrated?: PortalMigration;
 };
 
 type PortalDefaults = {
@@ -49,6 +60,10 @@ export function getPortalConfig(serverUrl: string): PortalConfig | null {
   });
 
   return portal || null;
+}
+
+export function getPortalMigration(serverUrl: string): PortalMigration | null {
+  return getPortalConfig(serverUrl)?.migrated ?? null;
 }
 
 export function getPortalSearchConfig(serverUrl: string): PortalSearchConfig {

--- a/tests/smoke/cases.json
+++ b/tests/smoke/cases.json
@@ -169,6 +169,19 @@
       "expect": {
         "count_min": 1
       }
+    },
+    {
+      "name": "a portal that left CKAN says so, not 'Unknown error'",
+      "regression": "catalog.data.gov answered 47 calls since April with a bare 404 while our docs called it CKAN (#540)",
+      "tool": "ckan_package_search",
+      "server": "https://catalog.data.gov",
+      "args": {
+        "q": "water",
+        "rows": 1
+      },
+      "expect": {
+        "error_matches": "stopped being a CKAN portal"
+      }
     }
   ]
 }

--- a/tests/unit/http.test.ts
+++ b/tests/unit/http.test.ts
@@ -767,6 +767,34 @@ describe('audit logging', () => {
 });
 
 describe('formatCkanError', () => {
+  it('a migrated portal gets the migration notice, whatever the status', () => {
+    // catalog.data.gov left CKAN in 2025 and answers every action with a bare 404:
+    // no status-based hint can be right for it, so the notice takes precedence.
+    for (const status of [404, 500, undefined]) {
+      const err = new CkanApiError('CKAN API error (404): Not Found', status, 'package_search', 'https://catalog.data.gov');
+      const result = formatCkanError(err, 'ckan_package_search');
+      expect(result).toContain('stopped being a CKAN portal');
+      expect(result).toContain('https://resources.data.gov/catalog-api/');
+      // The raw message stays, as with every other hint; what must not follow it is a
+      // status-based hint that would be wrong for this portal.
+      expect(result).not.toContain('retry later');
+      expect(result).not.toContain('ckan_package_search');
+    }
+  });
+
+  it('a working portal keeps the status-based hint', () => {
+    const err = new CkanApiError('CKAN API error (500): Internal Server Error', 500, 'package_search', 'https://open.canada.ca/data');
+    const result = formatCkanError(err, 'ckan_package_search');
+    expect(result).toContain('internal error');
+    expect(result).not.toContain('stopped being');
+  });
+
+  it('an error without a portal URL behaves as before', () => {
+    const err = new CkanApiError('CKAN API error (404): Not Found', 404, 'package_show');
+    expect(err.serverUrl).toBeUndefined();
+    expect(formatCkanError(err, 'ckan_package_show')).toContain('ckan_package_search');
+  });
+
   it('404 on datastore_search mentions ckan_package_show and datastore_active', () => {
     const err = new CkanApiError('CKAN API error (404): Not Found', 404, 'datastore_search');
     const result = formatCkanError(err, 'ckan_datastore_search');

--- a/tests/unit/portal-config.test.ts
+++ b/tests/unit/portal-config.test.ts
@@ -13,6 +13,13 @@ describe('getPortalMigration', () => {
     expect(getPortalMigration('https://catalog.data.gov/')).not.toBeNull();
   });
 
+  it('matches by hostname, as the request router does', () => {
+    // A host that left CKAN has left it for every spelling, port and path.
+    expect(getPortalMigration('https://CATALOG.DATA.GOV')).not.toBeNull();
+    expect(getPortalMigration('https://catalog.data.gov:443')).not.toBeNull();
+    expect(getPortalMigration('https://catalog.data.gov/dataset')).not.toBeNull();
+  });
+
   it('is null for a working portal and for an unknown host', () => {
     expect(getPortalMigration('https://open.canada.ca/data')).toBeNull();
     expect(getPortalMigration('https://example.org')).toBeNull();

--- a/tests/unit/portal-config.test.ts
+++ b/tests/unit/portal-config.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { getPortalMigration } from '../../src/utils/portal-config';
+import { describe, it, expect } from "vitest";
+import { getPortalMigration } from "../../src/utils/portal-config";
 
 describe('getPortalMigration', () => {
   it('returns the notice for a portal marked migrated', () => {

--- a/tests/unit/portal-config.test.ts
+++ b/tests/unit/portal-config.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { getPortalMigration } from '../../src/utils/portal-config';
+
+describe('getPortalMigration', () => {
+  it('returns the notice for a portal marked migrated', () => {
+    const m = getPortalMigration('https://catalog.data.gov');
+    expect(m?.notice).toContain('stopped being a CKAN portal');
+    expect(m?.docs_url).toMatch(/^https:\/\//);
+  });
+
+  it('matches the http alias and a trailing slash', () => {
+    expect(getPortalMigration('http://catalog.data.gov')).not.toBeNull();
+    expect(getPortalMigration('https://catalog.data.gov/')).not.toBeNull();
+  });
+
+  it('is null for a working portal and for an unknown host', () => {
+    expect(getPortalMigration('https://open.canada.ca/data')).toBeNull();
+    expect(getPortalMigration('https://example.org')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes the first half of #540.

## What a caller saw

```
ckan_package_search https://catalog.data.gov
→ CKAN API error (404): Unknown error
```

47 calls reached this portal through the public deployment since April. Meanwhile README, EXAMPLES, CLAUDE.md, the skill's country table, `src/README.md`, PRD, PRIVACY, `openspec/project.md` and the `ckan_organization_search` description all listed it as a working CKAN portal, "CKAN 2.11.4".

## What is true, verified 2026-09-06

Data.gov replaced its CKAN catalog with a Flask/OpenSearch application in 2025 ([GSA/datagov-catalog](https://github.com/GSA/datagov-catalog), [blog, 2026-04-15](https://data.gov/blog/catalog-update/)). The wiki said the legacy CKAN would stay at `catalog-old.data.gov` through fall 2026; it is already gone:

| endpoint | today |
|---|---|
| `catalog.data.gov/api/3/action/package_search` | 404 |
| `catalog-old.data.gov/api/3/action/…` | 301 → `catalog.data.gov` → 404 |
| `api.gsa.gov/technology/datagov/v3/action/…?api_key=DEMO_KEY` | 301 → `catalog.data.gov` → 404 |

The replacement, `api.gsa.gov/technology/datagov/v4/search`, needs a key, paginates with a cursor, returns DCAT-shaped records, and per GSA [will not support CKAN filter syntax](https://github.com/GSA/data.gov/issues/5680). A v4 adapter is a feature and stays in #540 as a separate proposal.

## What a caller sees now

```
CKAN API error (404): Unknown error
→ catalog.data.gov stopped being a CKAN portal in 2025. Data.gov now serves its catalog
  through a different API (api.gsa.gov/technology/datagov/v4, key required, not
  CKAN-compatible), which this server does not speak. See https://resources.data.gov/catalog-api/
```

Same from `ckan_status_show`, which used to say only "offline or not a valid CKAN instance".

## Changes

- `portals.json` entries can carry a `migrated` block (`notice`, `docs_url`). The `catalog-data-gov` entry is **kept and marked** rather than deleted, so the hint keeps firing for the callers who still try it.
- `CkanApiError` carries the portal URL the request went to. Additive: `status` and `action` unchanged.
- `formatCkanError` returns the migration notice for a migrated portal **whatever the status**, ahead of the status-based hints — such a portal answers every action alike, so no status-based hint can be right for it.
- `ckan_status_show` routes its error through `formatCkanError`.
- Every document that presented it as CKAN says the opposite. The skill's country table now reads `catalog.data.gov is NOT CKAN since 2025 (new API at api.gsa.gov v4, not supported)`, in the same form as the existing `data.gouv.fr is NOT CKAN` row — that line is what stops an LLM client from trying.

## Verification

- 542 tests, 6 added: notice on 404, 500 and `success=false`; a working portal keeps its status hint; an error without a URL behaves as before; `getPortalMigration` on the main URL, the http alias, a trailing slash, a working portal and an unknown host
- `npm run smoke`: 13/13, including a new case that calls the live portal and expects the notice
- OpenSpec change `mark-migrated-portals` on `ckan-error-hints`; `openspec validate --strict` green for specs and changes
- `grep catalog.data.gov` outside LOG and the archive finds only the migration note, the portals entry and the comment explaining it

## Left alone

`docs/DECISIONS.md` still describes the parser probe replaced in #534 and says configured portals skip it. Stale independently of this change; flagged in LOG.md, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEpSWpAwuMaGkfnMpQdqK2
