### PR TITLE
fix(scoring): a Solr operator is not an acronym

### DIFF
--- a/src/tools/package.ts
+++ b/src/tools/package.ts
@@ -228,14 +228,22 @@ const QUERY_STOPWORDS = new Set([
 const SOLR_OPERATORS = new Set(["AND", "OR", "NOT"]);
 
 export const extractQueryTerms = (query: string): string[] => {
-  const raw = query.normalize("NFC").match(/[\p{L}\p{N}]+/gu) ?? [];
+  const normalized = query.normalize("NFC");
+  const raw = normalized.match(/[\p{L}\p{N}]+/gu) ?? [];
+  // Inside double quotes Solr reads a keyword as a literal, so `"OR"` is a term to
+  // score on while a bare `OR` is syntax. Tokenisation has already dropped the quotes,
+  // so the quoted tokens are collected first.
+  const quoted = new Set<string>();
+  for (const m of normalized.matchAll(/"([^"]*)"/g)) {
+    for (const t of m[1].match(/[\p{L}\p{N}]+/gu) ?? []) quoted.add(t);
+  }
   // An all-caps token is an acronym, not an article: the stopword list is there for
   // `defibrillatori Comune di Lecce`, and must not swallow the `UN` of `UN population`
   // on a catalog in another language. Solr's own operators are the exception to the
   // exception — `aria OR acqua` is a query, not a mention of an organisation called OR.
   const terms = raw
     .filter((token) => {
-      if (SOLR_OPERATORS.has(token)) return false;
+      if (SOLR_OPERATORS.has(token) && !quoted.has(token)) return false;
       const term = token.toLowerCase();
       if (term.length <= 1) return false;
       if (!QUERY_STOPWORDS.has(term)) return true;

--- a/src/tools/package.ts
+++ b/src/tools/package.ts
@@ -234,7 +234,8 @@ export const extractQueryTerms = (query: string): string[] => {
   // score on while a bare `OR` is syntax. Tokenisation has already dropped the quotes,
   // so the quoted tokens are collected first.
   const quoted = new Set<string>();
-  for (const m of normalized.matchAll(/"([^"]*)"/g)) {
+  // `\"` inside a phrase is a literal quote, not the end of it: `"OR\" AND"` is one phrase.
+  for (const m of normalized.matchAll(/"((?:[^"\\]|\\.)*)"/g)) {
     for (const t of m[1].match(/[\p{L}\p{N}]+/gu) ?? []) quoted.add(t);
   }
   // An all-caps token is an acronym, not an article: the stopword list is there for

--- a/src/tools/package.ts
+++ b/src/tools/package.ts
@@ -224,13 +224,18 @@ const QUERY_STOPWORDS = new Set([
   "those"
 ]);
 
+/** Solr boolean keywords: all-caps by convention, never a term to score on. */
+const SOLR_OPERATORS = new Set(["AND", "OR", "NOT"]);
+
 export const extractQueryTerms = (query: string): string[] => {
   const raw = query.normalize("NFC").match(/[\p{L}\p{N}]+/gu) ?? [];
   // An all-caps token is an acronym, not an article: the stopword list is there for
   // `defibrillatori Comune di Lecce`, and must not swallow the `UN` of `UN population`
-  // on a catalog in another language.
+  // on a catalog in another language. Solr's own operators are the exception to the
+  // exception — `aria OR acqua` is a query, not a mention of an organisation called OR.
   const terms = raw
     .filter((token) => {
+      if (SOLR_OPERATORS.has(token)) return false;
       const term = token.toLowerCase();
       if (term.length <= 1) return false;
       if (!QUERY_STOPWORDS.has(term)) return true;

--- a/tests/unit/package-scoring.test.ts
+++ b/tests/unit/package-scoring.test.ts
@@ -649,6 +649,8 @@ describe('multilingual term extraction', () => {
   it('keeps a quoted operator: inside quotes Solr reads it as a literal', () => {
     expect(extractQueryTerms('"OR" Oregon')).toEqual(['or', 'oregon']);
     expect(extractQueryTerms('aria OR "AND"')).toEqual(['aria', 'and']);
+    // an escaped quote inside the phrase does not end it
+    expect(extractQueryTerms('"OR\\" AND" acqua')).toEqual(['or', 'and', 'acqua']);
   });
 
   it('matches across Unicode normal forms', () => {

--- a/tests/unit/package-scoring.test.ts
+++ b/tests/unit/package-scoring.test.ts
@@ -646,6 +646,11 @@ describe('multilingual term extraction', () => {
     expect(extractQueryTerms('water or sewage')).toEqual(['water', 'sewage']);
   });
 
+  it('keeps a quoted operator: inside quotes Solr reads it as a literal', () => {
+    expect(extractQueryTerms('"OR" Oregon')).toEqual(['or', 'oregon']);
+    expect(extractQueryTerms('aria OR "AND"')).toEqual(['aria', 'and']);
+  });
+
   it('matches across Unicode normal forms', () => {
     const nfd = 'mobilita\u0300 urbana';          // decomposed
     expect(countMatchingTerms(nfd, ['mobilità'])).toBe(1);

--- a/tests/unit/package-scoring.test.ts
+++ b/tests/unit/package-scoring.test.ts
@@ -637,6 +637,15 @@ describe('multilingual term extraction', () => {
     expect(extractQueryTerms('un comune di lecce')).toEqual(['comune', 'lecce']);
   });
 
+  it('never scores on a Solr operator, even though it is all-caps', () => {
+    // The acronym rule let `OR` through: `aria OR acqua` scored on three terms and
+    // a title carrying one of them got 4 × 1/3 instead of 4 × 1/2.
+    expect(extractQueryTerms('aria OR acqua')).toEqual(['aria', 'acqua']);
+    expect(extractQueryTerms('aria AND NOT rifiuti')).toEqual(['aria', 'rifiuti']);
+    // lowercase `or` was already a stopword; an English `Or` mid-sentence stays one too
+    expect(extractQueryTerms('water or sewage')).toEqual(['water', 'sewage']);
+  });
+
   it('matches across Unicode normal forms', () => {
     const nfd = 'mobilita\u0300 urbana';          // decomposed
     expect(countMatchingTerms(nfd, ['mobilità'])).toBe(1);


### PR DESCRIPTION
Found testing the local MCP client after #542: `ckan_find_relevant_datasets` on `aria OR acqua` reported `"terms": ["aria","or","acqua"]`.

The all-caps exception added in #536 — so that `UN population` keeps its `UN` — also let Solr's own operators through. `OR` is all-caps by convention, so it survived the stopword list and became a scoring term: a title carrying one of the two real terms scored 4 × 1/3 = 1.3 instead of 4 × 1/2 = 2. Result counts are unaffected (they come from Solr); the local ranking of every boolean query was diluted.

`AND`, `OR` and `NOT` are now dropped before the acronym rule. Lowercase `or` was already a stopword and stays one. Test added; 544 tests; the cross-tool smoke case passes.

Verified live on dati.comune.milano.it: terms `["aria","acqua"]`, title share 2 instead of 1.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEpSWpAwuMaGkfnMpQdqK2
