### PR TITLE
chore(release): v0.4.124

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -2,6 +2,13 @@
 
 ## 2026-09-06
 
+### v0.4.124 - search that answers the question that was asked
+
+Ships #542, #543, #544 and #545. For a caller: a query naming a place or an organisation
+now returns that place's datasets instead of any dataset on the topic; `catalog.data.gov`
+says where its data went instead of failing with "Unknown error"; `OR`, `AND` and `NOT`
+are treated as operators rather than words to score.
+
 ### Two gate cases for the strict pass, and one that was passing for free
 
 The `mm=100%` pass added in #544 was verified by hand, so nothing stopped it from

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "dxt_version": "0.1",
   "name": "ckan-mcp-server",
-  "version": "0.4.123",
+  "version": "0.4.124",
   "display_name": "CKAN MCP Server",
   "description": "Explore open data portals based on CKAN (dati.gov.it, data.gov, open.canada.ca, ...)",
   "long_description": "MCP server for interacting with CKAN-based open data portals. Provides tools for advanced dataset search with Solr syntax, DataStore queries for tabular data analysis, organization and group exploration, and complete metadata access.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aborruso/ckan-mcp-server",
-  "version": "0.4.123",
+  "version": "0.4.124",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aborruso/ckan-mcp-server",
-      "version": "0.4.123",
+      "version": "0.4.124",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aborruso/ckan-mcp-server",
-  "version": "0.4.123",
+  "version": "0.4.124",
   "mcpName": "io.github.aborruso/ckan-mcp-server",
   "description": "MCP server for interacting with CKAN open data portals",
   "repository": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/ondata/ckan-mcp-server",
     "source": "github"
   },
-  "version": "0.4.123",
+  "version": "0.4.124",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@aborruso/ckan-mcp-server",
-      "version": "0.4.123",
+      "version": "0.4.124",
       "transport": {
         "type": "stdio"
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,7 @@ import { registerAllPrompts } from "./prompts/index.js";
 export function createServer(): McpServer {
   return new McpServer({
     name: "ckan-mcp-server",
-    version: "0.4.123"
+    version: "0.4.124"
   });
 }
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -220,7 +220,7 @@ export default {
     if (request.method === 'GET' && url.pathname === '/health') {
       return new Response(JSON.stringify({
         status: 'ok',
-        version: '0.4.123',
+        version: '0.4.124',
         tools: 20,
         resources: 7,
         prompts: 6,


### PR DESCRIPTION
Release for #542, #543, #544 and #545.

## Version bump

`package.json`, `package-lock.json`, `manifest.json`, `server.json` (both fields), `src/server.ts`, `src/worker.ts`. No tools added or removed, so the `/health` count stays at 20.

```
$ grep -rn "0.4.123" package.json manifest.json server.json src/server.ts src/worker.ts
(nothing)
```

## Verification

- `npm run smoke` (release gate): 16/16
- `npm test`: 550 passed, 6 skipped
- `npm run build` and `npm run build:worker`: ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEpSWpAwuMaGkfnMpQdqK2
